### PR TITLE
fix: use correct response from apple device check api to trigger a DE…

### DIFF
--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/config/PpacConfiguration.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/config/PpacConfiguration.java
@@ -49,6 +49,16 @@ public class PpacConfiguration {
     private String ppacIosJwtSigningKey;
     private Integer minDeviceTokenLength;
     private Integer maxDeviceTokenLength;
+    private String missingOrIncorrectlyFormattedDeviceTokenPayload;
+
+    public String getMissingOrIncorrectlyFormattedDeviceTokenPayload() {
+      return missingOrIncorrectlyFormattedDeviceTokenPayload;
+    }
+
+    public void setMissingOrIncorrectlyFormattedDeviceTokenPayload(
+        String missingOrIncorrectlyFormattedDeviceTokenPayload) {
+      this.missingOrIncorrectlyFormattedDeviceTokenPayload = missingOrIncorrectlyFormattedDeviceTokenPayload;
+    }
 
     public String getPpacIosJwtKeyId() {
       return ppacIosJwtKeyId;

--- a/services/ppac/src/main/resources/application.yaml
+++ b/services/ppac/src/main/resources/application.yaml
@@ -43,6 +43,7 @@ server:
 ppac:
   otp-validity-in-hours: ${OTP_VALIDITY_IN_HOURS:1}
   ios:
+    missing-or-incorrectly-formatted-device-token-payload: Missing or incorrectly formatted device token payload
     ppac-ios-jwt-key-id: ${PPAC_IOS_JWT_KEY_ID}
     ppac-ios-jwt-signing-key: ${PPAC_IOS_JWT_SIGNING_KEY}
     ppac-ios-jwt-team-id: ${PPAC_IOS_JWT_TEAM_ID}


### PR DESCRIPTION
- use the correct response ""Missing or incorrectly formatted device token payload" from Apple's device check api to trigger a DEVICE_TOKEN_INVALID in case the device token was missing or badly formatted