### PR TITLE
fix: consistently use errorCode over errorState

### DIFF
--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/android/controller/AndroidApiErrorHandler.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/android/controller/AndroidApiErrorHandler.java
@@ -18,7 +18,7 @@ import app.coronawarn.datadonation.services.ppac.android.attestation.errors.Miss
 import app.coronawarn.datadonation.services.ppac.android.attestation.errors.NonceCalculationError;
 import app.coronawarn.datadonation.services.ppac.android.attestation.errors.NonceCouldNotBeVerified;
 import app.coronawarn.datadonation.services.ppac.android.attestation.errors.SaltNotValidAnymore;
-import app.coronawarn.datadonation.services.ppac.logging.PpacErrorState;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import java.util.Map;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -40,23 +40,23 @@ public class AndroidApiErrorHandler extends ResponseEntityExceptionHandler {
   /**
    * Mapping of business logic exceptions to codes delivered to the client.
    */
-  private static final Map<Class<? extends RuntimeException>, PpacErrorState> ERROR_STATES =
-      ofEntries(entry(FailedJwsParsing.class, PpacErrorState.JWS_SIGNATURE_VERIFICATION_FAILED),
-          entry(FailedSignatureVerification.class, PpacErrorState.JWS_SIGNATURE_VERIFICATION_FAILED),
-          entry(SaltNotValidAnymore.class, PpacErrorState.JWS_SIGNATURE_VERIFICATION_FAILED),
-          entry(FailedAttestationTimestampValidation.class, PpacErrorState.ATTESTATION_EXPIRED),
-          entry(NonceCouldNotBeVerified.class, PpacErrorState.NONCE_MISMATCH),
-          entry(ApkPackageNameNotAllowed.class, PpacErrorState.APK_PACKAGE_NAME_MISMATCH),
-          entry(ApkCertificateDigestsNotAllowed.class, PpacErrorState.APK_CERTIFICATE_MISMATCH),
-          entry(BasicIntegrityIsRequired.class, PpacErrorState.BASIC_INTEGRITY_REQUIRED), 
-          entry(CtsProfileMatchRequired.class, PpacErrorState.CTS_PROFILE_MATCH_REQUIRED), 
-          entry(BasicEvaluationTypeNotPresent.class, PpacErrorState.EVALUATION_TYPE_BASIC_REQUIRED),
-          entry(HardwareBackedEvaluationTypeNotPresent.class, PpacErrorState.EVALUATION_TYPE_HARDWARE_BACKED_REQUIRED));
+  private static final Map<Class<? extends RuntimeException>, PpacErrorCode> ERROR_CODES =
+      ofEntries(entry(FailedJwsParsing.class, PpacErrorCode.JWS_SIGNATURE_VERIFICATION_FAILED),
+          entry(FailedSignatureVerification.class, PpacErrorCode.JWS_SIGNATURE_VERIFICATION_FAILED),
+          entry(SaltNotValidAnymore.class, PpacErrorCode.JWS_SIGNATURE_VERIFICATION_FAILED),
+          entry(FailedAttestationTimestampValidation.class, PpacErrorCode.ATTESTATION_EXPIRED),
+          entry(NonceCouldNotBeVerified.class, PpacErrorCode.NONCE_MISMATCH),
+          entry(ApkPackageNameNotAllowed.class, PpacErrorCode.APK_PACKAGE_NAME_MISMATCH),
+          entry(ApkCertificateDigestsNotAllowed.class, PpacErrorCode.APK_CERTIFICATE_MISMATCH),
+          entry(BasicIntegrityIsRequired.class, PpacErrorCode.BASIC_INTEGRITY_REQUIRED), 
+          entry(CtsProfileMatchRequired.class, PpacErrorCode.CTS_PROFILE_MATCH_REQUIRED), 
+          entry(BasicEvaluationTypeNotPresent.class, PpacErrorCode.EVALUATION_TYPE_BASIC_REQUIRED),
+          entry(HardwareBackedEvaluationTypeNotPresent.class, PpacErrorCode.EVALUATION_TYPE_HARDWARE_BACKED_REQUIRED));
       
   @ExceptionHandler(value = {FailedJwsParsing.class, FailedSignatureVerification.class})
   protected ResponseEntity<Object> handleAuthenticationErrors(RuntimeException runtimeException,
       WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(runtimeException);
+    final PpacErrorCode errorCode = getErrorCode(runtimeException);
     errorCode.secureLog(securityLogger, runtimeException);
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(of(errorCode));
   }
@@ -68,7 +68,7 @@ public class AndroidApiErrorHandler extends ResponseEntityExceptionHandler {
       BasicEvaluationTypeNotPresent.class, HardwareBackedEvaluationTypeNotPresent.class})
   protected ResponseEntity<Object> handleForbiddenErrors(RuntimeException runtimeException,
       WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(runtimeException);
+    final PpacErrorCode errorCode = getErrorCode(runtimeException);
     errorCode.secureLog(securityLogger, runtimeException);
     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(of(errorCode));
   }
@@ -76,7 +76,7 @@ public class AndroidApiErrorHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = MissingMandatoryAuthenticationFields.class)
   protected ResponseEntity<Object> handleMissingInformationOrBadRequests(
       RuntimeException runtimeException, WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(runtimeException);
+    final PpacErrorCode errorCode = getErrorCode(runtimeException);
     errorCode.secureLog(securityLogger, runtimeException);
     return ResponseEntity.badRequest().body(of(errorCode));
   }
@@ -84,13 +84,13 @@ public class AndroidApiErrorHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = NonceCalculationError.class)
   protected ResponseEntity<Object> handleInternalServerErrors(RuntimeException runtimeException,
       WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(runtimeException);
+    final PpacErrorCode errorCode = getErrorCode(runtimeException);
     errorCode.secureLog(securityLogger, runtimeException);
-    return new ResponseEntity<>(PpacErrorState.INTERNAL_SERVER_ERROR, new HttpHeaders(),
+    return new ResponseEntity<>(PpacErrorCode.INTERNAL_SERVER_ERROR, new HttpHeaders(),
         HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
-  private PpacErrorState getErrorCode(RuntimeException runtimeException) {
-    return ERROR_STATES.getOrDefault(runtimeException.getClass(), PpacErrorState.UNKNOWN);
+  private PpacErrorCode getErrorCode(RuntimeException runtimeException) {
+    return ERROR_CODES.getOrDefault(runtimeException.getClass(), PpacErrorCode.UNKNOWN);
   }
 }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/commons/web/CommonApiErrorHandler.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/commons/web/CommonApiErrorHandler.java
@@ -1,12 +1,12 @@
 package app.coronawarn.datadonation.services.ppac.commons.web;
 
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.INTERNAL_SERVER_ERROR;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.INTERNAL_SERVER_ERROR;
 
 import app.coronawarn.datadonation.common.config.SecurityLogger;
 import app.coronawarn.datadonation.common.persistence.errors.MetricsDataCouldNotBeStored;
 import app.coronawarn.datadonation.services.ppac.commons.PpaDataRequestValidationFailed;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.InternalError;
-import app.coronawarn.datadonation.services.ppac.logging.PpacErrorState;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -24,9 +24,9 @@ public class CommonApiErrorHandler extends ResponseEntityExceptionHandler {
     this.securityLogger = securityLogger;
   }
 
-  private static final Map<Class<? extends RuntimeException>, PpacErrorState> ERROR_STATES =
-      Map.of(MetricsDataCouldNotBeStored.class, PpacErrorState.METRICS_DATA_NOT_VALID,
-          PpaDataRequestValidationFailed.class, PpacErrorState.METRICS_DATA_NOT_VALID,
+  private static final Map<Class<? extends RuntimeException>, PpacErrorCode> ERROR_CODES =
+      Map.of(MetricsDataCouldNotBeStored.class, PpacErrorCode.METRICS_DATA_NOT_VALID,
+          PpaDataRequestValidationFailed.class, PpacErrorCode.METRICS_DATA_NOT_VALID,
              InternalError.class, INTERNAL_SERVER_ERROR);
 
   @ExceptionHandler(value = {InternalError.class})
@@ -41,7 +41,7 @@ public class CommonApiErrorHandler extends ResponseEntityExceptionHandler {
     getErrorCode(e).secureLog(securityLogger, e);
   }
 
-  private PpacErrorState getErrorCode(RuntimeException runtimeException) {
-    return ERROR_STATES.getOrDefault(runtimeException.getClass(), PpacErrorState.UNKNOWN);
+  private PpacErrorCode getErrorCode(RuntimeException runtimeException) {
+    return ERROR_CODES.getOrDefault(runtimeException.getClass(), PpacErrorCode.UNKNOWN);
   }
 }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/commons/web/DataSubmissionResponse.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/commons/web/DataSubmissionResponse.java
@@ -1,24 +1,24 @@
 package app.coronawarn.datadonation.services.ppac.commons.web;
 
-import app.coronawarn.datadonation.services.ppac.logging.PpacErrorState;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 
 public class DataSubmissionResponse {
 
-  private PpacErrorState errorState;
+  private PpacErrorCode errorCode;
 
-  public PpacErrorState getErrorState() {
-    return errorState;
+  public PpacErrorCode getErrorCode() {
+    return errorCode;
   }
 
   /**
-   * Simple helper method to create a DataSubmissionResponse with the provided ErrorState {@link PpacErrorState}.
+   * Simple helper method to create a DataSubmissionResponse with the provided ErrorCode {@link PpacErrorCode}.
    *
-   * @param state the provided ErrorState.
+   * @param errorCode the provided ErrorCode.
    * @return a new instance of DataSubmissionResponse.
    */
-  public static DataSubmissionResponse of(PpacErrorState state) {
+  public static DataSubmissionResponse of(PpacErrorCode errorCode) {
     DataSubmissionResponse dataSubmissionResponse = new DataSubmissionResponse();
-    dataSubmissionResponse.errorState = state;
+    dataSubmissionResponse.errorCode = errorCode;
     return dataSubmissionResponse;
   }
 }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandler.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandler.java
@@ -1,12 +1,12 @@
 package app.coronawarn.datadonation.services.ppac.ios.controller;
 
 import static app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse.of;
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.API_TOKEN_EXPIRED;
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.API_TOKEN_QUOTA_EXCEEDED;
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.DEVICE_BLOCKED;
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.DEVICE_TOKEN_INVALID;
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.DEVICE_TOKEN_REDEEMED;
-import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorState.DEVICE_TOKEN_SYNTAX_ERROR;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.API_TOKEN_EXPIRED;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.API_TOKEN_QUOTA_EXCEEDED;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.DEVICE_BLOCKED;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.DEVICE_TOKEN_INVALID;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.DEVICE_TOKEN_REDEEMED;
+import static app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode.DEVICE_TOKEN_SYNTAX_ERROR;
 
 import app.coronawarn.datadonation.common.config.SecurityLogger;
 import app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse;
@@ -17,7 +17,7 @@ import app.coronawarn.datadonation.services.ppac.ios.verification.errors.DeviceB
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.DeviceTokenInvalid;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.DeviceTokenRedeemed;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.DeviceTokenSyntaxError;
-import app.coronawarn.datadonation.services.ppac.logging.PpacErrorState;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import java.util.Map;
 import javax.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
@@ -36,8 +36,8 @@ public class IosApiErrorHandler extends ResponseEntityExceptionHandler {
     this.securityLogger = securityLogger;
   }
 
-  private static final Map<Class<? extends RuntimeException>, PpacErrorState> ERROR_STATES =
-      Map.of(ApiTokenAlreadyUsed.class, PpacErrorState.API_TOKEN_ALREADY_ISSUED,
+  private static final Map<Class<? extends RuntimeException>, PpacErrorCode> ERROR_CODES =
+      Map.of(ApiTokenAlreadyUsed.class, PpacErrorCode.API_TOKEN_ALREADY_ISSUED,
           ApiTokenExpired.class, API_TOKEN_EXPIRED,
           DeviceTokenSyntaxError.class, DEVICE_TOKEN_SYNTAX_ERROR,
           DeviceTokenInvalid.class, DEVICE_TOKEN_INVALID,
@@ -49,7 +49,7 @@ public class IosApiErrorHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = {DeviceBlocked.class})
   protected ResponseEntity<Object> handleAuthenticationErrors(RuntimeException e,
       WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(e);
+    final PpacErrorCode errorCode = getErrorCode(e);
     errorCode.secureLog(securityLogger, e);
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(of(errorCode));
   }
@@ -58,7 +58,7 @@ public class IosApiErrorHandler extends ResponseEntityExceptionHandler {
       DeviceTokenInvalid.class})
   protected ResponseEntity<Object> handleBadRequests(RuntimeException e,
       WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(e);
+    final PpacErrorCode errorCode = getErrorCode(e);
     errorCode.secureLog(securityLogger, e);
     return ResponseEntity.badRequest().body(of(errorCode));
   }
@@ -68,7 +68,7 @@ public class IosApiErrorHandler extends ResponseEntityExceptionHandler {
   protected ResponseEntity<Object> handleForbiddenErrors(RuntimeException e,
       WebRequest webRequest) {
 
-    final PpacErrorState errorCode = getErrorCode(e);
+    final PpacErrorCode errorCode = getErrorCode(e);
     errorCode.secureLog(securityLogger, e);
     return ResponseEntity.status(HttpStatus.FORBIDDEN).body(of(errorCode));
   }
@@ -76,14 +76,14 @@ public class IosApiErrorHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = {ApiTokenQuotaExceeded.class})
   protected ResponseEntity<DataSubmissionResponse> handleTooManyRequestsErrors(RuntimeException e,
       WebRequest webRequest) {
-    final PpacErrorState errorCode = getErrorCode(e);
+    final PpacErrorCode errorCode = getErrorCode(e);
     errorCode.secureLog(securityLogger, e);
 
     return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
         .body(of(errorCode));
   }
 
-  private PpacErrorState getErrorCode(RuntimeException runtimeException) {
-    return ERROR_STATES.getOrDefault(runtimeException.getClass(), PpacErrorState.UNKNOWN);
+  private PpacErrorCode getErrorCode(RuntimeException runtimeException) {
+    return ERROR_CODES.getOrDefault(runtimeException.getClass(), PpacErrorCode.UNKNOWN);
   }
 }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/logging/PpacErrorCode.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/logging/PpacErrorCode.java
@@ -3,7 +3,7 @@ package app.coronawarn.datadonation.services.ppac.logging;
 import app.coronawarn.datadonation.common.config.SecurityLogger;
 import java.util.function.BiConsumer;
 
-public enum PpacErrorState {
+public enum PpacErrorCode {
   // iOS related error codes
   API_TOKEN_ALREADY_ISSUED(SecurityLogger::warn),
   API_TOKEN_EXPIRED(SecurityLogger::securityWarn),
@@ -38,7 +38,7 @@ public enum PpacErrorState {
 
   private final BiConsumer<SecurityLogger, RuntimeException> logInvocation;
 
-  PpacErrorState(BiConsumer<SecurityLogger, RuntimeException> logInvocation) {
+  PpacErrorCode(BiConsumer<SecurityLogger, RuntimeException> logInvocation) {
     this.logInvocation = logInvocation;
   }
 

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/IosAuthenticationIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/IosAuthenticationIntegrationTest.java
@@ -32,7 +32,7 @@ import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceData
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataUpdateRequest;
 import app.coronawarn.datadonation.services.ppac.ios.verification.JwtProvider;
-import app.coronawarn.datadonation.services.ppac.logging.PpacErrorState;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import feign.FeignException;
 import feign.Request;
 import feign.Request.Body;
@@ -114,7 +114,7 @@ public class IosAuthenticationIntegrationTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody()).isInstanceOf(DataSubmissionResponse.class);
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.DEVICE_TOKEN_SYNTAX_ERROR);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.DEVICE_TOKEN_SYNTAX_ERROR);
   }
 
   @Test
@@ -143,7 +143,7 @@ public class IosAuthenticationIntegrationTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody()).isInstanceOf(DataSubmissionResponse.class);
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.DEVICE_TOKEN_REDEEMED);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.DEVICE_TOKEN_REDEEMED);
   }
 
   @Test
@@ -235,7 +235,7 @@ public class IosAuthenticationIntegrationTest {
     assertThat(optionalApiToken.isPresent()).isEqualTo(false);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody()).isInstanceOf(DataSubmissionResponse.class);
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.API_TOKEN_ALREADY_ISSUED);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_ALREADY_ISSUED);
   }
 
   @Test
@@ -267,7 +267,7 @@ public class IosAuthenticationIntegrationTest {
     assertThat(apiTokenOptional.get().getExpirationDate()).isEqualTo(expirationDate);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody()).isInstanceOf(DataSubmissionResponse.class);
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.API_TOKEN_EXPIRED);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_EXPIRED);
   }
 
   @Test
@@ -286,7 +286,7 @@ public class IosAuthenticationIntegrationTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody()).isInstanceOf(DataSubmissionResponse.class);
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.DEVICE_TOKEN_INVALID);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.DEVICE_TOKEN_INVALID);
 
   }
 
@@ -329,7 +329,7 @@ public class IosAuthenticationIntegrationTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody()).isInstanceOf(DataSubmissionResponse.class);
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.DEVICE_BLOCKED);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.DEVICE_BLOCKED);
   }
 
   private FeignException.BadRequest buildFakeException(String msg) {

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/ApiTokenAuthenticatorIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/ApiTokenAuthenticatorIntegrationTest.java
@@ -10,7 +10,7 @@ import app.coronawarn.datadonation.services.ppac.config.PpacConfiguration;
 import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.ios.verification.apitoken.TestApiTokenAuthenticator;
-import app.coronawarn.datadonation.services.ppac.logging.PpacErrorState;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -115,6 +115,6 @@ public class ApiTokenAuthenticatorIntegrationTest {
     assertThat(skipValidationCaptor.getValue()).isFalse();
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     assertThat(optionalApiToken.isPresent()).isFalse();
-    assertThat(response.getBody().getErrorState()).isEqualTo(PpacErrorState.API_TOKEN_ALREADY_ISSUED);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_ALREADY_ISSUED);
   }
 }


### PR DESCRIPTION
PR replaces the term _error state_ and its variations with _error code_, especially so that the API consistently returns errorCode for both PPA and EDUS.

Related to https://github.com/corona-warn-app/cwa-app-tech-spec/pull/19/commits/966251fee6abf7e28a5c8506eb7948989b226c1a.