### PR TITLE
Fix log spam of Tomcat SSLHostConfig

### DIFF
--- a/services/edus/src/main/resources/application.yaml
+++ b/services/edus/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ server:
   shutdown: graceful
   ssl:
     enabled: true
-    enabled-protocols: TLSv1.2,TLSv1.3
+    enabled-protocols: TLSv1.2+TLSv1.3
     protocol: TLS
     ciphers: >-
       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/services/ppac/src/main/resources/application.yaml
+++ b/services/ppac/src/main/resources/application.yaml
@@ -20,7 +20,7 @@ server:
   shutdown: graceful
   ssl:
     enabled: true
-    enabled-protocols: TLSv1.2,TLSv1.3
+    enabled-protocols: TLSv1.2+TLSv1.3
     protocol: TLS
     ciphers: >-
       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256


### PR DESCRIPTION
Change way of listing supported TLS versions in application.yaml to purify tomcat complaints

similar to: https://github.com/corona-warn-app/cwa-server/pull/1197 for CWA-Server