### PR TITLE
feat: lower sec requirements for otp ppac

### DIFF
--- a/services/ppac/src/main/resources/application.yaml
+++ b/services/ppac/src/main/resources/application.yaml
@@ -86,13 +86,13 @@ ppac:
     disable-nonce-check: ${DISABLE_NONCE_CHECK:false}
     otp:
       # True to require basicIntegrity for PPAC to pass, false otherwise.
-      require-basic-integrity: ${ANDROID_OTP_REQUIRE_BASIC_INTEGRITY:true}
+      require-basic-integrity: ${ANDROID_OTP_REQUIRE_BASIC_INTEGRITY:false}
       # True to require ctsProfileMatch for PPAC to pass, false otherwise.
-      require-cts-profile-match: ${ANDROID_OTP_REQUIRE_CTS_PROFILE_MATCH:true}
+      require-cts-profile-match: ${ANDROID_OTP_REQUIRE_CTS_PROFILE_MATCH:false}
       # True to require evaluationType to contain BASIC for PPAC to pass, false otherwise.
       require-evaluation-type-basic: ${ANDROID_OTP_REQUIRE_EVALUATION_TYPE_BASIC:false}
       # True to require evaluationType to contain HARDWARE_BACKED for PPAC to pass, false otherwise.
-      require-evaluation-type-hardware-backed: ${ANDROID_OTP_REQUIRE_EVALUATION_TYPE_HARDWARE_BACKED:true}
+      require-evaluation-type-hardware-backed: ${ANDROID_OTP_REQUIRE_EVALUATION_TYPE_HARDWARE_BACKED:false}
     dat:
       # True to require basicIntegrity for PPAC to pass, false otherwise.
       require-basic-integrity: ${ANDROID_DAT_REQUIRE_BASIC_INTEGRITY:false}


### PR DESCRIPTION
aligned with https://github.com/corona-warn-app/cwa-server/compare/main...fix/edus-ppac-app-config
see https://github.com/corona-warn-app/cwa-app-tech-spec/pull/19/commits/c22a6f11bca0c867e8aba42ea65e39d94272d8e5