### PR TITLE
Grant SELECT to retention user role

### DIFF
--- a/setup/setup-access-control.sql
+++ b/setup/setup-access-control.sql
@@ -20,7 +20,7 @@ GRANT SELECT, INSERT, UPDATE ON TABLE
   data_donation.one_time_password
   TO cwa_ppdd_edus;
 
-GRANT DELETE ON TABLE
+GRANT SELECT, DELETE ON TABLE
     data_donation.api_token,
     data_donation.device_token,
     data_donation.exposure_risk_metadata,


### PR DESCRIPTION
## Description
This PR contains changes in order to grant SELECT permission for the role which is used in the retention service. The SELECT permission is needed due to the select statements executed when logging the number of the rows that are going to be deleted.