### PR TITLE
fix: add keystore for ppac and set password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
       POSTGRESQL_PASSWORD_PPAC: ${POSTGRES_PASSWORD}
       POSTGRESQL_SERVICE_PORT: '5432'
       POSTGRESQL_SERVICE_HOST: postgres-ppdd
+      SSL_DATA_KEYSTORE_PATH: file:/secrets/ssl.p12
+      SSL_DATA_KEYSTORE_PASSWORD: 123456
+    volumes:
+      - ./secrets:/secrets
   retention:
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       POSTGRESQL_PASSWORD_EDUS: ${POSTGRES_PASSWORD}
       POSTGRESQL_SERVICE_PORT: '5432'
       POSTGRESQL_SERVICE_HOST: postgres-ppdd
+      SSL_EDUS_KEYSTORE_PATH: file:/secrets/ssl.p12
+      SSL_EDUS_KEYSTORE_PASSWORD: 123456
+      SSL_EDUS_TRUSTSTORE_PATH: file:/secrets/truststore.jks
+      SSL_EDUS_TRUSTSTORE_PASSWORD: 123456
+    volumes:
+      - ./secrets:/secrets
   ppac:
     build:
       context: ./


### PR DESCRIPTION
- adds keystore and corresponding password (local env) to ppac service in docker-compose.yml