### PR TITLE
Fix Sonar project key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>corona-warn-app</sonar.organization>
-    <sonar.projectKey>${sonar.organization}_cwa-ppa-${project.artifactId}</sonar.projectKey>
+    <sonar.projectKey>${sonar.organization}_cwa-${project.artifactId}</sonar.projectKey>
 
     <!-- https://spring.io/projects/spring-boot -->
     <spring-boot.version>2.4.3</spring-boot.version>


### PR DESCRIPTION
## Description:
This PR contains changes to the Sonar project key:
- current resolved project key after property binding is :  corona-warn-app_cwa-ppa-ppa-server
- correct project key is: corona-warn-app_cwa-ppa-server
This incorrect binding leads to build failure in step `Analyze on SonarCloud` in CircleCI

![Screenshot 2021-03-03 at 17 57 11](https://user-images.githubusercontent.com/27012351/109834052-765a8500-7c4a-11eb-9478-646add5fbffc.png)
![Screenshot 2021-03-03 at 17 57 56](https://user-images.githubusercontent.com/27012351/109834062-79ee0c00-7c4a-11eb-87c7-b80068064a45.png)
