### PR TITLE
deactivate '/els' endpoints for release 1.2

### DIFF
--- a/services/edus/src/main/java/app/coronawarn/datadonation/services/edus/config/SecurityConfig.java
+++ b/services/edus/src/main/java/app/coronawarn/datadonation/services/edus/config/SecurityConfig.java
@@ -49,12 +49,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     expressionInterceptUrlRegistry
         .mvcMatchers(HttpMethod.POST, SURVEY + OTP).authenticated().and().x509()
         .userDetailsService(userDetailsService());
-    expressionInterceptUrlRegistry
-        .mvcMatchers(HttpMethod.POST, SURVEY + LOG).permitAll();
+    // TODO re-enable with release 2.0, but it won't be part of 1.2
+    //    expressionInterceptUrlRegistry
+    //        .mvcMatchers(HttpMethod.POST, SURVEY + LOG).permitAll();
     expressionInterceptUrlRegistry
         .mvcMatchers(HttpMethod.GET, HEALTH_ROUTE, PROMETHEUS_ROUTE, READINESS_ROUTE, LIVENESS_ROUTE).permitAll()
-        .mvcMatchers(HttpMethod.GET, GENERATE_OTP_ROUTE, GENERATE_ELS_OTP_ROUTE).permitAll();
-    expressionInterceptUrlRegistry
+        .mvcMatchers(HttpMethod.GET, GENERATE_OTP_ROUTE /*, GENERATE_ELS_OTP_ROUTE */).permitAll()
         .anyRequest().denyAll()
         .and().csrf().disable();
     http.headers().contentSecurityPolicy("default-src 'self'");

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/config/SecurityConfig.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/config/SecurityConfig.java
@@ -59,10 +59,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .mvcMatchers(HttpMethod.GET, HEALTH_ROUTE, PROMETHEUS_ROUTE, READINESS_ROUTE, LIVENESS_ROUTE).permitAll()
         .mvcMatchers(HttpMethod.POST, ANDROID_DATA_URL).permitAll()
         .mvcMatchers(HttpMethod.POST, ANDROID_OTP_URL).permitAll()
-        .mvcMatchers(HttpMethod.POST, ANDROID_LOG_OTP_URL).permitAll()
+        // TODO re-enable with release 2.0, but it won't be part of 1.2
+        //        .mvcMatchers(HttpMethod.POST, ANDROID_LOG_OTP_URL).permitAll()
         .mvcMatchers(HttpMethod.POST, IOS_DATA_URL).permitAll()
         .mvcMatchers(HttpMethod.POST, IOS_OTP_URL).permitAll()
-        .mvcMatchers(HttpMethod.POST, IOS_LOG_OTP_URL).permitAll()
+        // TODO re-enable with release 2.0, but it won't be part of 1.2
+        // .mvcMatchers(HttpMethod.POST, IOS_LOG_OTP_URL).permitAll()
         .anyRequest().denyAll()
         .and().csrf().disable();
     http.headers().contentSecurityPolicy("default-src 'self'");

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/android/controller/AndroidControllerTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/android/controller/AndroidControllerTest.java
@@ -6,8 +6,8 @@ import static app.coronawarn.datadonation.services.ppac.android.testdata.TestDat
 import static app.coronawarn.datadonation.services.ppac.android.testdata.TestData.newAuthenticationObject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,6 +18,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import app.coronawarn.datadonation.common.config.UrlConstants;
 import app.coronawarn.datadonation.common.persistence.domain.ElsOneTimePassword;
 import app.coronawarn.datadonation.common.persistence.domain.OneTimePassword;
 import app.coronawarn.datadonation.common.persistence.domain.ppac.android.Salt;
@@ -331,7 +332,12 @@ class AndroidControllerTest {
       assertThat(cptOtp.getAndroidPpacEvaluationTypeHardwareBacked()).isFalse();
     }
 
+    /**
+     * @throws IOException
+     * @see {@link UrlConstants#LOG}
+     */
     @Test
+    @Disabled("TODO re-enable with release 2.0, but it won't be part of 1.2")
     void testLogOtpServiceIsCalled() throws IOException {
       ppacConfiguration.getAndroid().setCertificateHostname("localhost");
       String password = "8ff92541-792f-4223-9970-bf90bf53b1a1";

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosControllerTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosControllerTest.java
@@ -8,8 +8,8 @@ import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.js
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postLogOtpCreationRequest;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postOtpCreationRequest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,10 +34,12 @@ import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.ios.verification.JwtProvider;
 import app.coronawarn.datadonation.services.ppac.ios.verification.apitoken.authentication.ApiTokenAuthenticationStrategy;
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -146,7 +148,12 @@ public class IosControllerTest {
       assertThat(cptOtp.getPassword()).isEqualTo(password);
     }
 
+    /**
+     * @throws IOException
+     * @see {@link UrlConstants#LOG}
+     */
     @Test
+    @Disabled("TODO re-enable with release 2.0, but it won't be part of 1.2")
     void testElsOtpServiceIsCalled() {
 
       PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);


### PR DESCRIPTION
ELS won't be delivered with 1.2 but with 2.0