### PR TITLE
fix: change device token createdAt to epoch second

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
@@ -43,22 +43,13 @@ public class TimeUtils {
   public static Long getEpochSecondFor(OffsetDateTime time) {
     return time.withOffsetSameInstant(ZoneOffset.UTC).toEpochSecond();
   }
-
-  /**
-   * Calculates the epoch seconds of the current timestamp.
-   *
-   * @return {@code Instant.now().getEpochSecond()}
-   */
-  public static Long getEpochSecondForNow() {
-    return Instant.now().getEpochSecond();
-  }
-
+  
   /**
    * Calculate the LocalDate based on epoch seconds in UTC.
    *
    * @param epochSecond the epoch seconds as reference point.
    * @return a LocalDate representing the provided epoch seconds.
-   * @throws DateTimeException if epochSecond > {@link Instant#MAX} or epochSecond < {@link Instant#MIN}  
+   * @throws DateTimeException if epochSecond > {@link Instant#MAX} or epochSecond < {@link Instant#MIN}
    */
   public static LocalDate getLocalDateFor(Long epochSecond) {
     return Instant.ofEpochSecond(epochSecond).atOffset(ZoneOffset.UTC).toLocalDate();

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacIosScenarioRepository.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacIosScenarioRepository.java
@@ -1,6 +1,6 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification;
 
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondForNow;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondsForNow;
 import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthForNow;
 
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
@@ -23,7 +23,7 @@ public class PpacIosScenarioRepository {
    * @param apiToken {@link String} Key of the API Token.
    */
   public void saveForEdus(ApiToken apiToken) {
-    Long currentTimeStamp = getEpochSecondForNow();
+    Long currentTimeStamp = getEpochSecondsForNow();
     Long expirationDate = getLastDayOfMonthForNow();
 
     try {
@@ -43,7 +43,7 @@ public class PpacIosScenarioRepository {
    * @param apiToken {@link String} Key of the API Token.
    */
   public void saveForPpa(ApiToken apiToken) {
-    Long currentTimeStamp = getEpochSecondForNow();
+    Long currentTimeStamp = getEpochSecondsForNow();
     Long expirationDate = getLastDayOfMonthForNow();
 
     try {
@@ -63,7 +63,7 @@ public class PpacIosScenarioRepository {
    * @param apiToken the apitoken to update.
    */
   public void updateForEdus(ApiToken apiToken) {
-    Long currentTimeStamp = getEpochSecondForNow();
+    Long currentTimeStamp = getEpochSecondsForNow();
     apiToken.setLastUsedEdus(currentTimeStamp);
     apiTokenRepository.save(apiToken);
   }
@@ -74,7 +74,7 @@ public class PpacIosScenarioRepository {
    * @param apiToken the apitoken to update.
    */
   public void updateForPpa(ApiToken apiToken) {
-    Long currentTimeStamp = getEpochSecondForNow();
+    Long currentTimeStamp = getEpochSecondsForNow();
     apiToken.setLastUsedPpac(currentTimeStamp);
     apiTokenRepository.save(apiToken);
   }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/devicedata/PerDeviceDataValidator.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/devicedata/PerDeviceDataValidator.java
@@ -66,7 +66,7 @@ public abstract class PerDeviceDataValidator {
     } catch (FeignException e) {
       treatGeneralRequestError(e);
     }
-    deviceTokenService.hashAndStoreDeviceToken(deviceToken, currentTimeStamp);
+    deviceTokenService.hashAndStoreDeviceToken(deviceToken);
     perDeviceDataResponseOptional.ifPresent(this::validateDeviceNotBlocked);
 
     return perDeviceDataResponseOptional.orElse(new PerDeviceDataResponse());

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/devicetoken/DeviceTokenService.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/devicetoken/DeviceTokenService.java
@@ -2,12 +2,12 @@ package app.coronawarn.datadonation.services.ppac.ios.verification.devicetoken;
 
 import app.coronawarn.datadonation.common.persistence.domain.DeviceToken;
 import app.coronawarn.datadonation.common.persistence.repository.DeviceTokenRepository;
+import app.coronawarn.datadonation.common.utils.TimeUtils;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.stereotype.Service;
 
@@ -27,14 +27,13 @@ public class DeviceTokenService {
   /**
    * Hashes a given DeviceToken with 'SHA-256' and stores it together with the current epoch seconds in UTC.
    *
-   * @param deviceToken      The input DeviceToken.
-   * @param currentTimeStamp The current Timestamp in Epoch Seconds and UTC.
+   * @param deviceToken The input DeviceToken.
    */
-  public void hashAndStoreDeviceToken(String deviceToken, Long currentTimeStamp) {
+  public void hashAndStoreDeviceToken(String deviceToken) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
       final byte[] tokenHash = digest.digest(deviceToken.getBytes(StandardCharsets.UTF_8));
-      DeviceToken newDeviceToken = new DeviceToken(tokenHash, currentTimeStamp);
+      DeviceToken newDeviceToken = new DeviceToken(tokenHash, TimeUtils.getEpochSecondsForNow());
       deviceTokenRepository.save(newDeviceToken);
     } catch (DbActionExecutionException | NoSuchAlgorithmException e) {
       redemptionStrategy.redeem(e);

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/IosAuthenticationIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/IosAuthenticationIntegrationTest.java
@@ -1,26 +1,5 @@
 package app.coronawarn.datadonation.services.ppac.ios;
 
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondForNow;
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthForNow;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildBase64String;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildDeviceToken;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildInvalidPPADataRequestIosPayload;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildIosDeviceData;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildPPADataRequestIosPayload;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildUuid;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.jsonify;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSubmission;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSurvey;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import app.coronawarn.datadonation.common.config.UrlConstants;
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.persistence.domain.DeviceToken;
@@ -43,11 +22,6 @@ import feign.FeignException;
 import feign.Request;
 import feign.Request.Body;
 import feign.Request.HttpMethod;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.temporal.TemporalAdjusters;
-import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -58,6 +32,18 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static app.coronawarn.datadonation.common.utils.TimeUtils.*;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class IosAuthenticationIntegrationTest {
@@ -155,7 +141,7 @@ public class IosAuthenticationIntegrationTest {
     final OffsetDateTime now = OffsetDateTime.now();
     final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
     final PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
-    apiTokenRepository.insert(apiToken, getLastDayOfMonthForNow(), getEpochSecondForNow(), null, null);
+    apiTokenRepository.insert(apiToken, getLastDayOfMonthForNow(), getEpochSecondsForNow(), null, null);
 
     when(iosDeviceApiClient.queryDeviceData(any(), any()))
         .thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
@@ -263,8 +249,6 @@ public class IosAuthenticationIntegrationTest {
         .findByDeviceTokenHash(
             buildDeviceToken(submissionPayloadIos.getAuthentication().getDeviceToken()).getDeviceTokenHash());
     assertThat(deviceTokenOptional).isPresent();
-    assertThat(deviceTokenOptional.get().getCreatedAt())
-        .isEqualTo(queryRequestArgumentCaptor.getValue().getTimestamp());
     assertThat(optionalApiToken).isPresent();
 
     final Long expirationDate = optionalApiToken.get().getExpirationDate();

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/apitoken/ApiTokenBuilderTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/apitoken/ApiTokenBuilderTest.java
@@ -16,7 +16,7 @@ class ApiTokenBuilderTest {
   void buildApiToken() {
     String apiToken = "apitoken";
 
-    final Long now = TimeUtils.getEpochSecondForNow();
+    final Long now = TimeUtils.getEpochSecondsForNow();
 
     final ApiToken newApiToken = ApiTokenBuilder.newBuilder()
         .setApiToken(apiToken)

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/PpaDataRequestIosConverterTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/PpaDataRequestIosConverterTest.java
@@ -36,7 +36,7 @@ public class PpaDataRequestIosConverterTest {
 
   @InjectMocks
   private PpaDataRequestIosConverter underTest;
-  
+
   private PpacConfiguration ppacConfig;
 
   @BeforeEach
@@ -45,10 +45,10 @@ public class PpaDataRequestIosConverterTest {
     ppacConfig.setMaxExposureWindowsToRejectSubmission(672);
     ppacConfig.setMaxExposureWindowsToStore(672);
   }
-  
+
   @Test
   public void testConvertToExposureWindow() {
-    final Long epochSecondForNow = TimeUtils.getEpochSecondForNow();
+    final Long epochSecondForNow = TimeUtils.getEpochSecondsForNow();
     LocalDate now = TimeUtils.getLocalDateFor(epochSecondForNow);
     final PPAExposureWindow ppaExposureWindow = PPAExposureWindow
         .newBuilder()
@@ -80,7 +80,7 @@ public class PpaDataRequestIosConverterTest {
   @Test
   public void testConvertExposureRiskMetaData() {
 
-    final Long epochSecondForNow = TimeUtils.getEpochSecondForNow();
+    final Long epochSecondForNow = TimeUtils.getEpochSecondsForNow();
     LocalDate now = TimeUtils.getLocalDateFor(epochSecondForNow);
     final ExposureRiskMetadata exposureRiskMetadataSrc = ExposureRiskMetadata.newBuilder()
         .setDateChangedComparedToPreviousSubmission(true)

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/testdata/TestData.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/testdata/TestData.java
@@ -3,7 +3,7 @@ package app.coronawarn.datadonation.services.ppac.ios.testdata;
 import static app.coronawarn.datadonation.common.protocols.internal.ppdd.PPALastSubmissionFlowScreen.SUBMISSION_FLOW_SCREEN_OTHER;
 import static app.coronawarn.datadonation.common.protocols.internal.ppdd.PPARiskLevel.RISK_LEVEL_HIGH;
 import static app.coronawarn.datadonation.common.protocols.internal.ppdd.PPATestResult.TEST_RESULT_POSITIVE;
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondForNow;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondsForNow;
 
 import app.coronawarn.datadonation.common.persistence.domain.DeviceToken;
 import app.coronawarn.datadonation.common.persistence.service.OtpCreationResponse;
@@ -127,7 +127,7 @@ public final class TestData {
   }
 
   private static PPADataIOS buildIosPayload() {
-    final Long epochSecondForNow = TimeUtils.getEpochSecondForNow();
+    final Long epochSecondForNow = TimeUtils.getEpochSecondsForNow();
 
     final PPAExposureWindow ppaExposureWindow = PPAExposureWindow
         .newBuilder()
@@ -205,6 +205,6 @@ public final class TestData {
       e.printStackTrace();
     }
     return new DeviceToken(digest.digest(deviceToken.getBytes(StandardCharsets.UTF_8)),
-        getEpochSecondForNow());
+        getEpochSecondsForNow());
   }
 }


### PR DESCRIPTION
- this pr introduces that DeviceTokens also use epoch seconds instead of milliseconds
- also it removes the duplicate function getEpochSecondsForNow