### PR TITLE
Hotfix/client abort exception 2

### DIFF
--- a/log4j2/default/log4j2-dev.xml
+++ b/log4j2/default/log4j2-dev.xml
@@ -17,8 +17,6 @@
     <Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
     <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
     <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
-    <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="error" />
-    <Logger name="org.apache.catalina.core.ContainerBase" level="off" />
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>

--- a/log4j2/default/log4j2-dev.xml
+++ b/log4j2/default/log4j2-dev.xml
@@ -17,6 +17,8 @@
     <Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
     <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
     <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
+    <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="error" />
+    <Logger name="org.apache.catalina.core.ContainerBase" level="off" />
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{1023}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %replace{%rException}{[\r\n]+}{\u2028}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100}}{CRLF} %rException{10, separator(\u2028)}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
@@ -17,7 +17,7 @@
     <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
     <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
     <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="error" />
-    <Logger name="org.apache.catalina.core.ContainerBase" level="off" />
+    <Logger name="org.apache.catalina.core.ContainerBase" level="error" />
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -17,6 +17,7 @@
     <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
     <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
     <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="error" />
+    <Logger name="org.apache.catalina.core.ContainerBase" level="off" />
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %rException{none, separator(\u2028)}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %exception{10}{separator(\u2028)} %n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -16,6 +16,7 @@
     <Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
     <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
     <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
+    <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="error" />
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %rException{10, separator(\u2028)}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %rException{none, separator(\u2028)}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">

--- a/log4j2/default/log4j2.xml
+++ b/log4j2/default/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ssZ</Property>
-    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100}}{CRLF} %rException{10, separator(\u2028)}%n</Property>
+    <Property name="CONSOLE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} %-5level %t %c{1.}[%pid]: %marker %enc{%maxLen{%m}{100000}}{CRLF} %rException{10, separator(\u2028)}%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
@@ -16,8 +16,6 @@
     <Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
     <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
     <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
-    <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="error" />
-    <Logger name="org.apache.catalina.core.ContainerBase" level="error" />
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>

--- a/log4j2/test/log4j2.xml
+++ b/log4j2/test/log4j2.xml
@@ -14,5 +14,14 @@
     <Root level="OFF">
       <AppenderRef ref="Console" />
     </Root>
+    <!-- For some reason, root level OFF doesn't suffice... -->
+    <Logger name="org.apache.catalina.startup.DigesterFactory" level="OFF" />
+    <Logger name="org.apache.catalina.util.LifecycleBase" level="OFF" />
+    <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="OFF" />
+    <Logger name="org.apache.sshd.common.util.SecurityUtils" level="OFF"/>
+    <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="OFF" />
+    <Logger name="org.hibernate.validator.internal.util.Version" level="OFF" />
+    <Logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="OFF" />
+    <Logger name="org.apache.catalina.core.ContainerBase" level="OFF" />
   </Loggers>
 </Configuration>

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandlerTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandlerTest.java
@@ -1,35 +1,30 @@
 package app.coronawarn.datadonation.services.ppac.ios.controller;
 
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildBase64String;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildDeviceToken;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildIosDeviceData;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildPPADataRequestIosPayload;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildUuid;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.jsonify;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSubmission;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSurvey;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import app.coronawarn.datadonation.common.config.UrlConstants;
-import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
-import app.coronawarn.datadonation.common.persistence.domain.DeviceToken;
 import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
-import app.coronawarn.datadonation.common.persistence.repository.DeviceTokenRepository;
-import app.coronawarn.datadonation.common.protocols.internal.ppdd.EDUSOneTimePasswordRequestIOS;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataRequestIOS;
 import app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse;
 import app.coronawarn.datadonation.services.ppac.config.PpacConfiguration;
 import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
-import app.coronawarn.datadonation.services.ppac.ios.testdata.TestData;
 import app.coronawarn.datadonation.services.ppac.ios.verification.JwtProvider;
 import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,16 +42,10 @@ public class IosApiErrorHandlerTest {
   // Then throws a ClientAbortException during exception handling
   // then see what happens...
 
-
   private static final String IOS_SERVICE_URL = UrlConstants.IOS + UrlConstants.DATA;
-  private static final String IOS_SURVEY_URL = UrlConstants.IOS + UrlConstants.OTP;
-  private static final OffsetDateTime OFFSET_DATE_TIME = OffsetDateTime.parse("2021-10-01T10:00:00+01:00");
 
   @Autowired
   private TestRestTemplate testRestTemplate;
-
-  @Autowired
-  private DeviceTokenRepository deviceTokenRepository;
 
   @Autowired
   private PpacConfiguration configuration;
@@ -75,52 +64,37 @@ public class IosApiErrorHandlerTest {
 
   @BeforeEach
   void clearDatabase() {
-    deviceTokenRepository.deleteAll();
     apiTokenRepository.deleteAll();
     when(jwtProvider.generateJwt()).thenReturn("jwt");
   }
 
   @Test
-  public void checkExceptionsInExceptionhandlerAreCaughtAndStatusCode500IsReturnedInResponse() {
-    final String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
-    final String deviceTokenForSurvey = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 2);
-    final String apiToken = buildUuid();
-    final String otp = buildUuid();
-    final OffsetDateTime now = OffsetDateTime.now();
-    final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
-    final PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
-    final EDUSOneTimePasswordRequestIOS edusOneTimePasswordRequestIOS = TestData
-        .buildEdusOneTimePasswordPayload(apiToken, deviceTokenForSurvey, otp);
+  public void testSubmitDataShouldNotThrowApiTokenQuotaExceeded() {
+    // Given a valid device Token and an existing ApiToken we need to check if
+    // this api token was already used today for PPA.
+    // If so then NORMALLY there would be a API_TOKEN_QUOTA_EXCEEDED
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    String apiToken = buildUuid();
+    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+    OffsetDateTime now = OffsetDateTime.now();
+    Long expirationDate = getLastDayOfMonthFor(now);
+    long timestamp = getEpochSecondFor(now);
+    apiTokenRepository.insert(apiToken, expirationDate, expirationDate, timestamp, timestamp);
 
-    when(iosDeviceApiClient.queryDeviceData(any(), any()))
-        .thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
+    // Triggering the ClientAbortException is not easy, as this is pretty low-level in the call stack
+    // For more info, see https://stackoverflow.com/a/38733497/58997
+    // Instead, set a breakpoint in org.apache.catalina.connector.OutputBuffer.doFlush(OutputBuffer.java:305)
+    // and manually trigger the exception in the debugger:
+    // IntelliJ: Right Click on the StackFrame -> Throw Exception
 
-    final ResponseEntity<DataSubmissionResponse> responseEntity = postSubmission(submissionPayloadIos, testRestTemplate,
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
+    ResponseEntity<DataSubmissionResponse> response = postSubmission(submissionPayloadIos, testRestTemplate,
         IOS_SERVICE_URL, false);
-    final ResponseEntity<DataSubmissionResponse> surveyResponseEntity = postSurvey(edusOneTimePasswordRequestIOS,
-        testRestTemplate,
-        IOS_SURVEY_URL, false);
 
-    final DeviceToken newDeviceToken = buildDeviceToken(submissionPayloadIos.getAuthentication().getDeviceToken());
-    final DeviceToken newSurveyDeviceToken = buildDeviceToken(
-        edusOneTimePasswordRequestIOS.getAuthentication().getDeviceToken());
-
-    final Optional<DeviceToken> byDeviceTokenHash = deviceTokenRepository
-        .findByDeviceTokenHash(newDeviceToken.getDeviceTokenHash());
-    final Optional<DeviceToken> surveyDeviceToken = deviceTokenRepository
-        .findByDeviceTokenHash(newSurveyDeviceToken.getDeviceTokenHash());
-    final Optional<ApiToken> apiTokenOptional = apiTokenRepository.findById(apiToken);
-
-    final String secondDeviceTokenForSurvey = buildBase64String(
-        this.configuration.getIos().getMinDeviceTokenLength() + 3);
-    final EDUSOneTimePasswordRequestIOS secondEdusOneTimePasswordRequestIOS = TestData
-        .buildEdusOneTimePasswordPayload(apiToken, secondDeviceTokenForSurvey, otp);
-
-    final ResponseEntity<DataSubmissionResponse> errorResponse = postSurvey(secondEdusOneTimePasswordRequestIOS,
-        testRestTemplate,
-        IOS_SURVEY_URL, false);
-    assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
-    assertThat(errorResponse.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_QUOTA_EXCEEDED);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_QUOTA_EXCEEDED);
     verify(iosApiErrorHandler, times(1)).handleTooManyRequestsErrors(any(), any());
+
   }
 }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandlerTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandlerTest.java
@@ -1,0 +1,79 @@
+package app.coronawarn.datadonation.services.ppac.ios.controller;
+
+import static app.coronawarn.datadonation.common.config.UrlConstants.DATA;
+import static app.coronawarn.datadonation.common.config.UrlConstants.IOS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.coronawarn.datadonation.common.config.SecurityLogger;
+import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataIOS;
+import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPAExposureWindow;
+import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPAExposureWindowInfectiousness;
+import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPANewExposureWindow;
+import app.coronawarn.datadonation.common.utils.TimeUtils;
+import java.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IosApiErrorHandlerTest {
+
+  private MockMvc mockMvc;
+
+  @Mock
+  private IosController iosController;
+
+  private SecurityLogger logger;
+
+  @Before
+  public void setup() {
+    openMocks(this);
+    logger = mock(SecurityLogger.class);
+    this.mockMvc = MockMvcBuilders.standaloneSetup(iosController)
+        .setControllerAdvice(new IosApiErrorHandler(logger))
+        .build();
+  }
+
+  @Test
+  public void checkUnexpectedExceptionsAreCaughtAndStatusCode500IsReturnedInResponse() throws Exception {
+    doThrow(RuntimeException.class).when(logger).securityWarn(any());
+    doThrow(RuntimeException.class).when(logger).error(any());
+    doThrow(RuntimeException.class).when(iosController).submitData(anyBoolean(), any());
+
+    final Long epochSecondForNow = TimeUtils.getEpochSecondForNow();
+    LocalDate now = TimeUtils.getLocalDateFor(epochSecondForNow);
+    final PPAExposureWindow ppaExposureWindow = PPAExposureWindow
+        .newBuilder()
+        .setCalibrationConfidence(1)
+        .setInfectiousness(PPAExposureWindowInfectiousness.INFECTIOUSNESS_HIGH)
+        .setDate(epochSecondForNow)
+        .build();
+
+    final PPANewExposureWindow ppaNewExposureWindow = PPANewExposureWindow
+        .newBuilder()
+        .setExposureWindow(ppaExposureWindow)
+        .build();
+
+    final PPADataIOS payload = PPADataIOS.newBuilder()
+        .addNewExposureWindows(ppaNewExposureWindow).build();
+
+    MockHttpServletRequestBuilder request = post(IOS + DATA);
+    request.contentType(MediaType.valueOf("application/x-protobuf"));
+    request.header("cwa-ppac-ios-accept-api-token", "true");
+    request.content(payload.toByteArray());
+
+    mockMvc.perform(request).andExpect(status().isInternalServerError());
+  }
+}

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandlerTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/controller/IosApiErrorHandlerTest.java
@@ -2,78 +2,135 @@ package app.coronawarn.datadonation.services.ppac.ios.controller;
 
 import static app.coronawarn.datadonation.common.config.UrlConstants.DATA;
 import static app.coronawarn.datadonation.common.config.UrlConstants.IOS;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.MockitoAnnotations.openMocks;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.*;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.*;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSurvey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import app.coronawarn.datadonation.common.config.SecurityLogger;
+import app.coronawarn.datadonation.common.config.UrlConstants;
+import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
+import app.coronawarn.datadonation.common.persistence.domain.DeviceToken;
+import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
+import app.coronawarn.datadonation.common.persistence.repository.DeviceTokenRepository;
+import app.coronawarn.datadonation.common.protocols.internal.ppdd.EDUSOneTimePasswordRequestIOS;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataIOS;
+import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataRequestIOS;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPAExposureWindow;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPAExposureWindowInfectiousness;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPANewExposureWindow;
 import app.coronawarn.datadonation.common.utils.TimeUtils;
+import app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse;
+import app.coronawarn.datadonation.services.ppac.config.PpacConfiguration;
+import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
+import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
+import app.coronawarn.datadonation.services.ppac.ios.testdata.TestData;
+import app.coronawarn.datadonation.services.ppac.ios.verification.JwtProvider;
+import app.coronawarn.datadonation.services.ppac.ios.verification.PpacIosScenarioRepository;
 import java.time.LocalDate;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import app.coronawarn.datadonation.services.ppac.ios.verification.devicetoken.DeviceTokenRedemptionStrategy;
+import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-@RunWith(MockitoJUnitRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class IosApiErrorHandlerTest {
 
-  private MockMvc mockMvc;
+  // Create a setup that throws an ApiTokenQuotaExceeded during processing
+  // Then throws a ClientAbortException during exception handling
+  // then see what happens...
 
-  @Mock
-  private IosController iosController;
 
-  private SecurityLogger logger;
+  private static final String IOS_SERVICE_URL = UrlConstants.IOS + UrlConstants.DATA;
+  private static final String IOS_SURVEY_URL = UrlConstants.IOS + UrlConstants.OTP;
+  private static final OffsetDateTime OFFSET_DATE_TIME = OffsetDateTime.parse("2021-10-01T10:00:00+01:00");
 
-  @Before
-  public void setup() {
-    openMocks(this);
-    logger = mock(SecurityLogger.class);
-    this.mockMvc = MockMvcBuilders.standaloneSetup(iosController)
-        .setControllerAdvice(new IosApiErrorHandler(logger))
-        .build();
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+
+  @Autowired
+  private DeviceTokenRepository deviceTokenRepository;
+
+  @Autowired
+  private PpacConfiguration configuration;
+
+  @MockBean
+  private IosDeviceApiClient iosDeviceApiClient;
+
+  @MockBean
+  private JwtProvider jwtProvider;
+
+  @SpyBean
+  PpacIosScenarioRepository scenarioRepository;
+
+  @Autowired
+  ApiTokenRepository apiTokenRepository;
+
+  @BeforeEach
+  void clearDatabase() {
+    deviceTokenRepository.deleteAll();
+    apiTokenRepository.deleteAll();
+    when(jwtProvider.generateJwt()).thenReturn("jwt");
   }
 
   @Test
-  public void checkUnexpectedExceptionsAreCaughtAndStatusCode500IsReturnedInResponse() throws Exception {
-    doThrow(RuntimeException.class).when(logger).securityWarn(any());
-    doThrow(RuntimeException.class).when(logger).error(any());
-    doThrow(RuntimeException.class).when(iosController).submitData(anyBoolean(), any());
+  public void checkExceptionsInExceptionhandlerAreCaughtAndStatusCode500IsReturnedInResponse() {
+    final String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    final String deviceTokenForSurvey = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 2);
+    final String apiToken = buildUuid();
+    final String otp = buildUuid();
+    final OffsetDateTime now = OffsetDateTime.now();
+    final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
+    final PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+    final EDUSOneTimePasswordRequestIOS edusOneTimePasswordRequestIOS = TestData
+        .buildEdusOneTimePasswordPayload(apiToken, deviceTokenForSurvey, otp);
 
-    final Long epochSecondForNow = TimeUtils.getEpochSecondForNow();
-    LocalDate now = TimeUtils.getLocalDateFor(epochSecondForNow);
-    final PPAExposureWindow ppaExposureWindow = PPAExposureWindow
-        .newBuilder()
-        .setCalibrationConfidence(1)
-        .setInfectiousness(PPAExposureWindowInfectiousness.INFECTIOUSNESS_HIGH)
-        .setDate(epochSecondForNow)
-        .build();
+    when(iosDeviceApiClient.queryDeviceData(any(), any()))
+        .thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
 
-    final PPANewExposureWindow ppaNewExposureWindow = PPANewExposureWindow
-        .newBuilder()
-        .setExposureWindow(ppaExposureWindow)
-        .build();
+    final ResponseEntity<DataSubmissionResponse> responseEntity = postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, false);
+    final ResponseEntity<DataSubmissionResponse> surveyResponseEntity = postSurvey(edusOneTimePasswordRequestIOS,
+        testRestTemplate,
+        IOS_SURVEY_URL, false);
 
-    final PPADataIOS payload = PPADataIOS.newBuilder()
-        .addNewExposureWindows(ppaNewExposureWindow).build();
+    final DeviceToken newDeviceToken = buildDeviceToken(submissionPayloadIos.getAuthentication().getDeviceToken());
+    final DeviceToken newSurveyDeviceToken = buildDeviceToken(
+        edusOneTimePasswordRequestIOS.getAuthentication().getDeviceToken());
 
-    MockHttpServletRequestBuilder request = post(IOS + DATA);
-    request.contentType(MediaType.valueOf("application/x-protobuf"));
-    request.header("cwa-ppac-ios-accept-api-token", "true");
-    request.content(payload.toByteArray());
+    final Optional<DeviceToken> byDeviceTokenHash = deviceTokenRepository
+        .findByDeviceTokenHash(newDeviceToken.getDeviceTokenHash());
+    final Optional<DeviceToken> surveyDeviceToken = deviceTokenRepository
+        .findByDeviceTokenHash(newSurveyDeviceToken.getDeviceTokenHash());
+    final Optional<ApiToken> apiTokenOptional = apiTokenRepository.findById(apiToken);
 
-    mockMvc.perform(request).andExpect(status().isInternalServerError());
+    final String secondDeviceTokenForSurvey = buildBase64String(
+        this.configuration.getIos().getMinDeviceTokenLength() + 3);
+    final EDUSOneTimePasswordRequestIOS secondEdusOneTimePasswordRequestIOS = TestData
+        .buildEdusOneTimePasswordPayload(apiToken, secondDeviceTokenForSurvey, otp);
+
+    final ResponseEntity<DataSubmissionResponse> errorResponse = postSurvey(secondEdusOneTimePasswordRequestIOS,
+        testRestTemplate,
+        IOS_SURVEY_URL, false);
+    assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(errorResponse.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_QUOTA_EXCEEDED);
   }
 }


### PR DESCRIPTION
As of my testing, these changes seem to fix the error of _way_ too much being logged.

Reduces the logging to 
```
2021-03-16T13:55:30+0100 WARN  http-nio-auto-1-exec-1 a.c.d.s.p.l.PpacLogger[78234]: SECURITY PPAC failed due to Api Token quota exceeded  
2021-03-16T13:55:42+0100 WARN  http-nio-auto-1-exec-1 o.s.w.s.m.m.a.ExceptionHandlerExceptionResolver[78234]:  Failure in @ExceptionHandler app.coronawarn.datadonation.services.ppac.ios.controller.IosApiErrorHandler$MockitoMock$808227129#handleTooManyRequestsErrors(RuntimeException, WebRequest) org.apache.catalina.connector.ClientAbortException\u2028	at org.apache.catalina.connector.OutputBuffer.doFlush(OutputBuffer.java:305)\u2028	at org.apache.catalina.connector.OutputBuffer.flush(OutputBuffer.java:272)\u2028	at org.apache.catalina.connector.CoyoteOutputStream.flush(CoyoteOutputStream.java:118)\u2028	at org.springframework.security.web.util.OnCommittedResponseWrapper$SaveContextServletOutputStream.flush(OnCommittedResponseWrapper.java:523)\u2028	at org.springframework.security.web.util.OnCommittedResponseWrapper$SaveContextServletOutputStream.flush(OnCommittedResponseWrapper.java:523)\u2028	at java.base/java.io.FilterOutputStream.flush(FilterOutputStream.java:153)\u2028	at com.fasterxml.jackson.core.json.UTF8JsonGenerator.flush(UTF8JsonGenerator.java:1178)\u2028	at com.fasterxml.jackson.databind.ObjectWriter.writeValue(ObjectWriter.java:1008)\u2028	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.writeInternal(AbstractJackson2HttpMessageConverter.java:452) 
2021-03-16T13:55:59+0100 ERROR http-nio-auto-1-exec-1 o.a.c.c.C.[.[.[.[dispatcherServlet][78234]:  Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded: PPAC failed due to Api Token quota exceeded] with root cause app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded: PPAC failed due to Api Token quota exceeded\u2028	at app.coronawarn.datadonation.services.ppac.ios.verification.scenario.ratelimit.ProdPpacIosRateLimitStrategy.lambda$validateForPpa$1(ProdPpacIosRateLimitStrategy.java:43)\u2028	at java.base/java.util.Optional.ifPresent(Optional.java:183)\u2028	at app.coronawarn.datadonation.services.ppac.ios.verification.scenario.ratelimit.ProdPpacIosRateLimitStrategy.validateForPpa(ProdPpacIosRateLimitStrategy.java:39)\u2028	at app.coronawarn.datadonation.services.ppac.commons.PpacScenario.validate(PpacScenario.java:46)\u2028	at app.coronawarn.datadonation.services.ppac.ios.verification.apitoken.ApiTokenService.authenticateExistingApiToken(ApiTokenService.java:90)\u2028	at app.coronawarn.datadonation.services.ppac.ios.verification.apitoken.ApiTokenService.validate(ApiTokenService.java:78)\u2028	at app.coronawarn.datadonation.services.ppac.ios.verification.apitoken.ApiTokenService$$FastClassBySpringCGLIB$$6f0dc22a.invoke(<generated>)\u2028	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)\u2028	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:779) 
```