### PR TITLE
Managed spring vault core dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
     <spring-boot.version>2.4.4</spring-boot.version>
     <!-- https://spring.io/projects/spring-cloud#release-trains -->
     <spring-cloud.version>2020.0.2</spring-cloud.version>
+    <!-- If you update spring-cloud, see if it references the correct spring-vault-core version again, then remove the following: -->
+    <spring-vault-core.version>2.3.2</spring-vault-core.version>
     <spring-retry.version>1.3.1</spring-retry.version>
     <protobuf.version>3.15.6</protobuf.version>
     <json-simple.version>1.1.1</json-simple.version>
@@ -247,7 +249,7 @@
       <dependency>
         <groupId>org.springframework.vault</groupId>
         <artifactId>spring-vault-core</artifactId>
-        <version>2.3.2</version>
+        <version>${spring-vault-core.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Since the wrong dependency to spring-vault-core 2.3.0 is defined in the spring-cloud-dependencies pom, we need to explicitly define the dependency to override the wrong version number.

Exclusions aren't possible with Maven import scope, which would be preferable:

The import scope can be used to include dependency management information from a remote POM into the current project. One of the limitations of this is that it does not allow additional excludes to be defined for a multi module project.

Likewise, there is a confirmation from the Spring Boot documentation:

If you have added spring-boot-dependencies in your own dependencyManagement section with import you have to redefine the artifact yourself [...].