### PR TITLE
Use UTC time instead of default time-zone

### DIFF
--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/apitoken/authentication/ApiTokenAuthenticationStrategy.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/apitoken/authentication/ApiTokenAuthenticationStrategy.java
@@ -4,6 +4,7 @@ import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenAlreadyUsed;
 import java.time.YearMonth;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public interface ApiTokenAuthenticationStrategy {
@@ -24,7 +25,7 @@ public interface ApiTokenAuthenticationStrategy {
     final YearMonth lastUpdated = YearMonth.parse(
         perDeviceDataLastUpdated,
         DateTimeFormatter.ofPattern("yyyy-MM"));
-    if (YearMonth.now().equals(lastUpdated)) {
+    if (YearMonth.now(ZoneOffset.UTC).equals(lastUpdated)) {
       throw new ApiTokenAlreadyUsed();
     }
   }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/testdata/TestData.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/testdata/TestData.java
@@ -26,7 +26,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.UUID;
@@ -51,7 +53,8 @@ public final class TestData {
       data.setBit0(true);
       data.setBit1(true);
     }
-    data.setLastUpdated(lastUpdated.format(DateTimeFormatter.ofPattern("yyyy-MM")));
+    LocalDateTime utcBasedTime = lastUpdated.atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    data.setLastUpdated(utcBasedTime.format(DateTimeFormatter.ofPattern("yyyy-MM")));
     return data;
   }
 


### PR DESCRIPTION
According to spec, this should be UTC time, but implementation obtained the current year-month from the system clock in the default time-zone.

See spec: https://github.com/corona-warn-app/cwa-app-tech-spec/blob/proposal/privacy-preserving-analytics/docs/spec/data-donation-server.md#ios-ppa-specific-handling-of-ppac