### PR TITLE
fix warning for SSLHostConfig

### DIFF
--- a/services/edus/src/main/resources/application.yaml
+++ b/services/edus/src/main/resources/application.yaml
@@ -51,7 +51,7 @@ management:
     port: 8081
     ssl:
       enabled: true
-      enabled-protocols: TLSv1.2,TLSv1.3
+      enabled-protocols: TLSv1.2+TLSv1.3
       protocol: TLS
       ciphers: >-
         TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256


### PR DESCRIPTION
fix warning:

`WARN main o.a.t.u.n.SSLHostConfig[1]: The protocol [TLSv1.3] was added to the list of protocols on the SSLHostConfig named [default]. Check if a +/- prefix is missing.`