### PR TITLE
Add Cascade Delete Constraint for ScanInstances (release 2.4)

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,4 @@
--Drevision=2.4.0
+-Drevision=2.5.0-SNAPSHOT
 -Dlicense.projectName=Corona-Warn-App
 -Dlicense.inceptionYear=2020
 -Dlicense.licenseName=apache_v2

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,4 @@
--Drevision=2.5.0-SNAPSHOT
+-Drevision=2.4.0
 -Dlicense.projectName=Corona-Warn-App
 -Dlicense.inceptionYear=2020
 -Dlicense.licenseName=apache_v2

--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/persistence/repository/metrics/ScanInstanceRepository.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/persistence/repository/metrics/ScanInstanceRepository.java
@@ -1,0 +1,10 @@
+package app.coronawarn.datadonation.common.persistence.repository.metrics;
+
+import app.coronawarn.datadonation.common.persistence.domain.metrics.ScanInstance;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScanInstanceRepository extends CrudRepository<ScanInstance, Long> {
+
+}

--- a/common/persistence/src/main/resources/db/migration/V10__alterScanInstanceTable.sql
+++ b/common/persistence/src/main/resources/db/migration/V10__alterScanInstanceTable.sql
@@ -1,3 +1,8 @@
+DELETE FROM scan_instance
+    WHERE NOT EXISTS (
+        SELECT 1 FROM exposure_window WHERE exposure_window_id=exposure_window.id
+    );
+
 ALTER TABLE scan_instance
   ADD CONSTRAINT fk_exposure_window_id FOREIGN KEY (exposure_window_id)
   REFERENCES exposure_window(id)

--- a/common/persistence/src/main/resources/db/migration/V10__alterScanInstanceTable.sql
+++ b/common/persistence/src/main/resources/db/migration/V10__alterScanInstanceTable.sql
@@ -1,0 +1,4 @@
+ALTER TABLE scan_instance
+  ADD CONSTRAINT fk_exposure_window_id FOREIGN KEY (exposure_window_id)
+  REFERENCES exposure_window(id)
+  ON DELETE CASCADE;

--- a/common/persistence/src/main/resources/db/specific/postgresql/V8__createRandomDataGenerationProcedure.sql
+++ b/common/persistence/src/main/resources/db/specific/postgresql/V8__createRandomDataGenerationProcedure.sql
@@ -26,8 +26,7 @@ CREATE OR REPLACE FUNCTION data_donation.random_string(num_characters integer)
 	END;
 	$$;
 
-CREATE OR REPLACE FUNCTION data_donation.generate_test_data(num integer)
-	RETURNS VOID
+CREATE OR REPLACE PROCEDURE data_donation.generate_test_data(num integer)
 	LANGUAGE plpgsql
 	AS $$
 	BEGIN

--- a/common/persistence/src/test/java/app/coronawarn/datadonation/common/persistence/repository/metrics/ExposureWindowRepositoryTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/datadonation/common/persistence/repository/metrics/ExposureWindowRepositoryTest.java
@@ -1,22 +1,26 @@
 package app.coronawarn.datadonation.common.persistence.repository.metrics;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import app.coronawarn.datadonation.common.persistence.domain.metrics.ExposureWindow;
 import app.coronawarn.datadonation.common.persistence.domain.metrics.ScanInstance;
 import app.coronawarn.datadonation.common.persistence.domain.metrics.TechnicalMetadata;
 import app.coronawarn.datadonation.common.persistence.domain.metrics.embeddable.ClientMetadataDetails;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @DataJdbcTest
 class ExposureWindowRepositoryTest {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       PGADMIN_DEFAULT_EMAIL: admin
       PGADMIN_DEFAULT_PASSWORD: admin
   postgres-ppdd:
-    image: postgres:11.8
+    image: postgres:11.5
     restart: always
     ports:
       - 8102:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pgadmin-ppdd:
-    image: dpage/pgadmin4:4.16
+    image: dpage/pgadmin4
     volumes:
       - pgadmin_volume:/root/.pgadmin
     ports:


### PR DESCRIPTION
- alters the ScanInstance Table so that when deleting ExposureWindows the corresponding ScanInstances will also be deleted