### PR TITLE
Revert "Bump maven-dependency-plugin from 3.1.2 to 3.2.0 (#250)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
This reverts commit 53b532290820150efbb3d412e3cd657f14982b93.

`mvn dependency:tree -DoutputFile=mvn_dependency_tree.txt -Dverbose -DoutputType=text -T1`
doesn't work anymore with version `3.2.0`