### PR TITLE
Fix/rate limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <spring-retry.version>1.3.1</spring-retry.version>
     <protobuf.version>3.17.3</protobuf.version>
     <json-simple.version>1.1.1</json-simple.version>
-    <feign.version>11.5</feign.version>
+    <feign.version>11.6</feign.version>
     <bouncycastle.version>1.69</bouncycastle.version>
     <dom4j.version>2.1.3</dom4j.version>
     <guava.version>30.1.1-jre</guava.version>

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/apitoken/ApiTokenService.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/apitoken/ApiTokenService.java
@@ -1,5 +1,7 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification.apitoken;
 
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochMilliSecondForNow;
+
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPACIOS;
@@ -16,12 +18,10 @@ import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiToke
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.InternalServerError;
 import app.coronawarn.datadonation.services.ppac.ios.verification.scenario.ratelimit.PpacIosRateLimitStrategy;
 import feign.FeignException;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Optional;
-
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochMilliSecondForNow;
 
 public abstract class ApiTokenService {
 

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
@@ -5,14 +5,21 @@ import static app.coronawarn.datadonation.common.utils.TimeUtils.getLocalDateFor
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!loadtest")
 public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProdPpacIosRateLimitStrategy.class);
+  private static final int VALIDITY_IN_HOURS = 23;
 
   /**
    * Check Rate Limit for EDUS Scenario. ApiToken in a EDUS Scenario can only be used once a month.
@@ -36,12 +43,26 @@ public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
    * @param apiToken the ApiToken that needs to be validated.
    */
   public void validateForPpa(ApiToken apiToken) {
-    apiToken.getLastUsedPpac().ifPresent(it -> {
+    apiToken.getLastUsedPpac().ifPresent(getLastUsedEpochSecond -> {
       LocalDate currentDateUtc = TimeUtils.getLocalDateForNow();
-      LocalDate lastUsedForPpaUtc = getLocalDateFor(it);
+      LocalDate lastUsedForPpaUtc = getLocalDateFor(getLastUsedEpochSecond);
+
+      logLastUpdate(getLastUsedEpochSecond, currentDateUtc, lastUsedForPpaUtc);
+
       if (currentDateUtc.isEqual(lastUsedForPpaUtc)) {
         throw new ApiTokenQuotaExceeded();
       }
     });
+  }
+
+  private void logLastUpdate(Long getLastUsedEpochSecond, final LocalDate currentDateUtc,
+      final LocalDate lastUsedForPpaUtc) {
+    Instant lastUsedTimeStamp = Instant.ofEpochSecond(getLastUsedEpochSecond);
+    Instant currentTimeStamp = Instant.now();
+    final long diff = ChronoUnit.HOURS.between(lastUsedTimeStamp, currentTimeStamp);
+    if (diff == VALIDITY_IN_HOURS && currentDateUtc.equals(lastUsedForPpaUtc)) {
+      logger.info("Api Token was updated {} hours ago on the same day. Api Token can only be used once a day {}.", diff,
+          currentTimeStamp.truncatedTo(ChronoUnit.MINUTES));
+    }
   }
 }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
@@ -1,19 +1,18 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification.scenario.ratelimit;
 
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getLocalDateFor;
+
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
-
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getLocalDateFor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!loadtest")

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
@@ -34,7 +34,6 @@ public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
         throw new ApiTokenQuotaExceeded();
       }
     });
-
   }
 
   /**

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
@@ -1,25 +1,26 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification.scenario.ratelimit;
 
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getLocalDateFor;
-
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.YearMonth;
-import java.time.temporal.ChronoUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getLocalDateFor;
 
 @Component
 @Profile("!loadtest")
 public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
 
   private static final Logger logger = LoggerFactory.getLogger(ProdPpacIosRateLimitStrategy.class);
-  private static final int VALIDITY_IN_HOURS = 23;
+  static final int VALIDITY_IN_HOURS = 23;
 
   /**
    * Check Rate Limit for EDUS Scenario. ApiToken in a EDUS Scenario can only be used once a month.
@@ -45,8 +46,7 @@ public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
     apiToken.getLastUsedPpac().ifPresent(getLastUsedEpochSecond -> {
       LocalDate currentDateUtc = TimeUtils.getLocalDateForNow();
       LocalDate lastUsedForPpaUtc = getLocalDateFor(getLastUsedEpochSecond);
-
-      logLastUpdate(getLastUsedEpochSecond, currentDateUtc, lastUsedForPpaUtc);
+      logLastUpdate(getLastUsedEpochSecond, currentDateUtc, lastUsedForPpaUtc, Instant.now());
 
       if (currentDateUtc.isEqual(lastUsedForPpaUtc)) {
         throw new ApiTokenQuotaExceeded();
@@ -54,14 +54,14 @@ public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
     });
   }
 
-  private void logLastUpdate(Long getLastUsedEpochSecond, final LocalDate currentDateUtc,
-      final LocalDate lastUsedForPpaUtc) {
+  static long logLastUpdate(Long getLastUsedEpochSecond, final LocalDate currentDateUtc,
+      final LocalDate lastUsedForPpaUtc, Instant currentTimeStamp) {
     Instant lastUsedTimeStamp = Instant.ofEpochSecond(getLastUsedEpochSecond);
-    Instant currentTimeStamp = Instant.now();
     final long diff = ChronoUnit.HOURS.between(lastUsedTimeStamp, currentTimeStamp);
     if (diff == VALIDITY_IN_HOURS && currentDateUtc.equals(lastUsedForPpaUtc)) {
       logger.info("Api Token was updated {} hours ago on the same day. Api Token can only be used once a day {}.", diff,
           currentTimeStamp.truncatedTo(ChronoUnit.MINUTES));
     }
+    return diff;
   }
 }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
@@ -34,7 +34,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-
 @Profile("test")
 public class PpaIosIntegrationTest {
 
@@ -61,7 +60,7 @@ public class PpaIosIntegrationTest {
   }
 
   @Test
-  public void testSavePpaDataRequestIos() {
+  void testSavePpaDataRequestIos() {
     PPADataRequestIOS ppaDataRequestIOS = buildPPADataRequestIosPayload(buildUuid(),
         buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
     PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);
@@ -70,7 +69,7 @@ public class PpaIosIntegrationTest {
   }
 
   @Test
-  public void shouldFailWhenUpdatingDeviceTokenFails() {
+  void shouldFailWhenUpdatingDeviceTokenFails() {
     PPADataRequestIOS ppaDataRequestIOS = buildPPADataRequestIosPayload(buildUuid(),
         buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
     PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
@@ -67,6 +67,7 @@ public class PpaIosIntegrationTest {
     when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
     final ResponseEntity<DataSubmissionResponse> responseEntity = postSubmission(
         ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
+
     assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
@@ -56,6 +56,8 @@ public class PpaIosIntegrationTest {
 
   @BeforeEach
   void clearDatabase() {
+    deviceTokenRepository.deleteAll();
+    apiTokenRepository.deleteAll();
     when(jwtProvider.generateJwt()).thenReturn("jwt");
   }
 
@@ -76,8 +78,9 @@ public class PpaIosIntegrationTest {
   void shouldFailWhenUpdatingDeviceTokenFails() {
     PPADataRequestIOS ppaDataRequestIOS = buildPPADataRequestIosPayload(buildUuid(),
         buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
-    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);
-    when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenThrow(FeignException.class);
+    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now().minusMonths(1), true);
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
+    when(iosDeviceApiClient.updatePerDeviceData(anyString(), any())).thenThrow(FeignException.class);
     final ResponseEntity<DataSubmissionResponse> response = postSubmission(
         ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
 

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
@@ -65,6 +65,7 @@ public class PpaIosIntegrationTest {
         buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
     PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now().minusMonths(1), true);
     when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
+    when(iosDeviceApiClient.updatePerDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok().build());
     final ResponseEntity<DataSubmissionResponse> responseEntity = postSubmission(
         ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
 

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
@@ -6,6 +6,7 @@ import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.bu
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildUuid;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.jsonify;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSubmission;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -21,7 +22,6 @@ import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceData
 import app.coronawarn.datadonation.services.ppac.ios.verification.JwtProvider;
 import feign.FeignException;
 import java.time.OffsetDateTime;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,9 +63,11 @@ public class PpaIosIntegrationTest {
   void testSavePpaDataRequestIos() {
     PPADataRequestIOS ppaDataRequestIOS = buildPPADataRequestIosPayload(buildUuid(),
         buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
-    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);
+    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now().minusMonths(1), true);
     when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
-    postSubmission(ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
+    final ResponseEntity<DataSubmissionResponse> responseEntity = postSubmission(
+        ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
   @Test
@@ -77,7 +79,6 @@ public class PpaIosIntegrationTest {
     final ResponseEntity<DataSubmissionResponse> response = postSubmission(
         ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
 
-    Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
   }
-
 }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
@@ -1,36 +1,37 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification;
 
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import app.coronawarn.datadonation.common.config.UrlConstants;
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataRequestIOS;
+import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse;
 import app.coronawarn.datadonation.services.ppac.config.PpacConfiguration;
 import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
-import java.time.OffsetDateTime;
-import java.util.Optional;
+import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class PpacProcessorIntegrationTest {
@@ -62,6 +63,77 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
+  public void testNewApiTokenNotSavedWhenFurtherProcessingFails() {
+    // given
+    // - a valid ApiToken that was created now.
+    String apiToken = buildUuid();
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+    // - a device token
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    // - a data submission payload
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+
+    // when
+    // - checking the device token then return some valid mock data.
+    final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any()))
+        .thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
+    // - when updating the device data then fail
+    when(iosDeviceApiClient.updatePerDeviceData(anyString(), any()))
+        .thenThrow(FeignException.class);
+    // then
+    // - failed submission
+    final ResponseEntity<DataSubmissionResponse> dataSubmissionResponseResponseEntity = postSubmission(
+        submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, true);
+    Optional<ApiToken> optionalApiToken = apiTokenRepository.findById(apiToken);
+    // - the api token was not created.
+    assertThat(optionalApiToken).isEmpty();
+  }
+
+  @Test
+  public void testExistingApiTokenRollbackAppliedWhenFurtherProcessingFails() {
+    // given
+    // - a valid ApiToken that was created now and was last used for PPA the day before. The Api Token is valid until the end of the current Month.
+    String apiToken = buildUuid();
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    final Long lastDayOfMonthForNow = TimeUtils.getLastDayOfMonthForNow();
+    final Long createdAt = now.toEpochSecond();
+    final long lastUsedForPpa = now.minus(1, ChronoUnit.DAYS).toEpochSecond();
+    apiTokenRepository.insert(apiToken, lastDayOfMonthForNow, createdAt, null, lastUsedForPpa);
+    // - a device token
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    // - a data submission payload
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+
+    // when
+    // - checking the device first throw an exception and second return some valid mock data.
+    final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any()))
+        .thenThrow(new RuntimeException()).thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
+    // then
+    // - failed submission
+    postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, true);
+    Optional<ApiToken> optionalApiToken = apiTokenRepository.findById(apiToken);
+    // - the api token's last updated timestamp is still the old one
+    assertThat(optionalApiToken).isNotEmpty();
+    assertThat(optionalApiToken.get().getLastUsedPpac()).isPresent();
+    assertThat(optionalApiToken.get().getLastUsedPpac().get()).isEqualTo(lastUsedForPpa);
+    // then
+    // - successful submission
+    postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, true);
+    Optional<ApiToken> optionalApiToken1 = apiTokenRepository.findById(apiToken);
+    // - the api token's last updated timestamp is somewhere near the createdAt timestamp.
+    assertThat(optionalApiToken1).isNotEmpty();
+    assertThat(optionalApiToken1.get().getLastUsedPpac()).isPresent();
+    assertThat(optionalApiToken1.get().getLastUsedPpac().get())
+        .isCloseTo(createdAt, within(createdAt - lastUsedForPpa));
+  }
+
+  @Test
   public void testApiTokenQuotaExceededShouldNotTriggerAppleCall() {
     String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
     String apiToken = buildUuid();
@@ -82,20 +154,20 @@ public class PpacProcessorIntegrationTest {
 
   @Test
   public void testApiTokenExpiredShouldNotTriggerAppleCall() {
-      String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
-      String apiToken = buildUuid();
-      OffsetDateTime now = OffsetDateTime.now();
-      Long expirationDate = getLastDayOfMonthFor(now.minusMonths(1));
-      long timestamp = getEpochSecondFor(now);
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    String apiToken = buildUuid();
+    OffsetDateTime now = OffsetDateTime.now();
+    Long expirationDate = getLastDayOfMonthFor(now.minusMonths(1));
+    long timestamp = getEpochSecondFor(now);
 
-      apiTokenRepository.insert(apiToken, expirationDate, expirationDate, timestamp, timestamp);
-      PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+    apiTokenRepository.insert(apiToken, expirationDate, expirationDate, timestamp, timestamp);
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
 
-      ResponseEntity<DataSubmissionResponse> response = postSubmission(submissionPayloadIos, testRestTemplate,
-          IOS_SERVICE_URL, false);
+    ResponseEntity<DataSubmissionResponse> response = postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, false);
 
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-      assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_EXPIRED);
-      verify(iosDeviceApiClient, times(0)).queryDeviceData(anyString(), any());
-    }
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_EXPIRED);
+    verify(iosDeviceApiClient, times(0)).queryDeviceData(anyString(), any());
+  }
 }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
@@ -1,5 +1,21 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification;
 
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
+import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildBase64String;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildIosDeviceData;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildPPADataRequestIosPayload;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildUuid;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.jsonify;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSubmission;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import app.coronawarn.datadonation.common.config.UrlConstants;
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
@@ -11,6 +27,10 @@ import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
 import feign.FeignException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,19 +39,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
-import java.util.Optional;
-
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
-import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class PpacProcessorIntegrationTest {

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
@@ -91,9 +91,7 @@ public class PpacProcessorIntegrationTest {
         .thenThrow(FeignException.class);
     // then
     // - failed submission
-    final ResponseEntity<DataSubmissionResponse> dataSubmissionResponseResponseEntity = postSubmission(
-        submissionPayloadIos, testRestTemplate,
-        IOS_SERVICE_URL, true);
+    postSubmission(submissionPayloadIos, testRestTemplate, IOS_SERVICE_URL, true);
     Optional<ApiToken> optionalApiToken = apiTokenRepository.findById(apiToken);
     // - the api token was not created.
     assertThat(optionalApiToken).isEmpty();

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
@@ -70,7 +70,7 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
-  public void testNewApiTokenNotSavedWhenFurtherProcessingFails() {
+  void testNewApiTokenNotSavedWhenFurtherProcessingFails() {
     // given
     // - a valid ApiToken that was created now.
     String apiToken = buildUuid();
@@ -100,7 +100,7 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
-  public void testExistingApiTokenRollbackAppliedWhenFurtherProcessingFails() {
+  void testExistingApiTokenRollbackAppliedWhenFurtherProcessingFails() {
     // given
     // - a valid ApiToken that was created now and was last used for PPA the day before. The Api Token is valid until the end of the current Month.
     String apiToken = buildUuid();
@@ -141,7 +141,7 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
-  public void testApiTokenQuotaExceededShouldNotTriggerAppleCall() {
+  void testApiTokenQuotaExceededShouldNotTriggerAppleCall() {
     String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
     String apiToken = buildUuid();
     OffsetDateTime now = OffsetDateTime.now();
@@ -160,7 +160,7 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
-  public void testApiTokenExpiredShouldNotTriggerAppleCall() {
+  void testApiTokenExpiredShouldNotTriggerAppleCall() {
     String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
     String apiToken = buildUuid();
     OffsetDateTime now = OffsetDateTime.now();

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategyTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategyTest.java
@@ -1,8 +1,18 @@
 package app.coronawarn.datadonation.services.ppac.ios.verification.scenario.ratelimit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,19 +21,22 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
 public class ProdPpacIosRateLimitStrategyTest {
 
   @InjectMocks
   ProdPpacIosRateLimitStrategy underTest;
+
+  @Test
+  void shouldLogDiff23HoursWhenUpdatingApiTOkenOnSameDay() {
+    // given
+    long lastUpdated = Instant.parse("2020-01-01T00:05:00Z").getEpochSecond();
+    LocalDate localDate = LocalDate.parse("2020-01-01");
+    Instant now = Instant.parse("2020-01-01T23:05:01Z");
+    final long diff = ProdPpacIosRateLimitStrategy.logLastUpdate(lastUpdated, localDate, localDate, now);
+    assertThat(diff).isEqualTo(ProdPpacIosRateLimitStrategy.VALIDITY_IN_HOURS);
+  }
 
   @Test
   void shouldThrowExceptionWhenValidateForEdusIsNotOnTheSameMonth() {


### PR DESCRIPTION
- further improvment to handle 429's
- validateLocally is not transactional anymore
- the update of the apitoken is not validateLocally but at the end of ppac
- additional tests
- additional log to see if there are api tokens that are updated twice a day ( with a diff of 23 hours)