### PR TITLE
Fix/rate limit (#274)

### DIFF
--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/apitoken/ApiTokenService.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/apitoken/ApiTokenService.java
@@ -63,7 +63,7 @@ public abstract class ApiTokenService {
    * @param ignoreApiTokenAlreadyIssued flag to indicate whether the ApiToken should be validated against the last
    *                                    updated time from the per-device Data.
    * @throws ApiTokenAlreadyUsed - in case the ApiToken was already issued this month.
-   * @throws InternalServerError       - in case updating the per-device Data was not successful.
+   * @throws InternalServerError - in case updating the per-device Data was not successful.
    */
   @Transactional
   public void validate(
@@ -79,33 +79,30 @@ public abstract class ApiTokenService {
           transactionId,
           ignoreApiTokenAlreadyIssued,
           ppacScenario);
+    } else {
+      ppacScenario.update(ppacIosScenarioRepository, apiTokenOptional.get());
     }
   }
 
   /**
-   * Authenticate an incoming request if the provided ApiToken does already exist.
-   * Then its expiration data is checked as well as the rate limit.
+   * Authenticate an incoming request if the provided ApiToken does already exist. Then its expiration data is checked
+   * as well as the rate limit.
    *
-   * @param ppacios                   the client request.
-   * @param ppacScenario              the scenario we are currently in.
-   *
-   * @throws ApiTokenExpired          - in case the ApiToken already expired.
-   * @throws ApiTokenQuotaExceeded    - in case the client has run into the rate limit.
+   * @param ppacios      the client request.
+   * @param ppacScenario the scenario we are currently in.
+   * @throws ApiTokenExpired       - in case the ApiToken already expired.
+   * @throws ApiTokenQuotaExceeded - in case the client has run into the rate limit.
    */
-  @Transactional
   public void validateLocally(
       PPACIOS ppacios,
       PpacScenario ppacScenario) {
     Optional<ApiToken> apiTokenOptional = apiTokenRepository.findById(ppacios.getApiToken());
-    if (apiTokenOptional.isPresent()) {
-      authenticateExistingApiToken(apiTokenOptional.get(), ppacScenario);
-    }
+    apiTokenOptional.ifPresent(apiToken -> authenticateExistingApiToken(apiToken, ppacScenario));
   }
 
   private void authenticateExistingApiToken(ApiToken apiToken, PpacScenario scenario) {
     apiTokenAuthenticationStrategy.checkApiTokenNotAlreadyExpired(apiToken);
     scenario.validate(iosScenarioValidator, apiToken);
-    scenario.update(ppacIosScenarioRepository, apiToken);
   }
 
   private void authenticateNewApiToken(PerDeviceDataResponse perDeviceDataResponse,

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategy.java
@@ -5,14 +5,21 @@ import static app.coronawarn.datadonation.common.utils.TimeUtils.getLocalDateFor
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.ios.verification.errors.ApiTokenQuotaExceeded;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!loadtest")
 public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProdPpacIosRateLimitStrategy.class);
+  static final int VALIDITY_IN_HOURS = 23;
 
   /**
    * Check Rate Limit for EDUS Scenario. ApiToken in a EDUS Scenario can only be used once a month.
@@ -27,7 +34,6 @@ public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
         throw new ApiTokenQuotaExceeded();
       }
     });
-
   }
 
   /**
@@ -36,12 +42,25 @@ public class ProdPpacIosRateLimitStrategy implements PpacIosRateLimitStrategy {
    * @param apiToken the ApiToken that needs to be validated.
    */
   public void validateForPpa(ApiToken apiToken) {
-    apiToken.getLastUsedPpac().ifPresent(it -> {
+    apiToken.getLastUsedPpac().ifPresent(getLastUsedEpochSecond -> {
       LocalDate currentDateUtc = TimeUtils.getLocalDateForNow();
-      LocalDate lastUsedForPpaUtc = getLocalDateFor(it);
+      LocalDate lastUsedForPpaUtc = getLocalDateFor(getLastUsedEpochSecond);
+      logLastUpdate(getLastUsedEpochSecond, currentDateUtc, lastUsedForPpaUtc, Instant.now());
+
       if (currentDateUtc.isEqual(lastUsedForPpaUtc)) {
         throw new ApiTokenQuotaExceeded();
       }
     });
+  }
+
+  static long logLastUpdate(Long getLastUsedEpochSecond, final LocalDate currentDateUtc,
+      final LocalDate lastUsedForPpaUtc, Instant currentTimeStamp) {
+    Instant lastUsedTimeStamp = Instant.ofEpochSecond(getLastUsedEpochSecond);
+    final long diff = ChronoUnit.HOURS.between(lastUsedTimeStamp, currentTimeStamp);
+    if (diff == VALIDITY_IN_HOURS && currentDateUtc.equals(lastUsedForPpaUtc)) {
+      logger.info("Api Token was updated {} hours ago on the same day. Api Token can only be used once a day {}.", diff,
+          currentTimeStamp.truncatedTo(ChronoUnit.MINUTES));
+    }
+    return diff;
   }
 }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/PpaIosIntegrationTest.java
@@ -6,6 +6,7 @@ import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.bu
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildUuid;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.jsonify;
 import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSubmission;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -14,10 +15,12 @@ import app.coronawarn.datadonation.common.config.UrlConstants;
 import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
 import app.coronawarn.datadonation.common.persistence.repository.DeviceTokenRepository;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataRequestIOS;
+import app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse;
 import app.coronawarn.datadonation.services.ppac.config.PpacConfiguration;
 import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.ios.verification.JwtProvider;
+import feign.FeignException;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,10 +30,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-
 @Profile("test")
 public class PpaIosIntegrationTest {
 
@@ -53,16 +56,34 @@ public class PpaIosIntegrationTest {
 
   @BeforeEach
   void clearDatabase() {
+    deviceTokenRepository.deleteAll();
+    apiTokenRepository.deleteAll();
     when(jwtProvider.generateJwt()).thenReturn("jwt");
   }
 
   @Test
-  public void testSavePpaDataRequestIos() {
+  void testSavePpaDataRequestIos() {
     PPADataRequestIOS ppaDataRequestIOS = buildPPADataRequestIosPayload(buildUuid(),
         buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
-    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now(), true);
+    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now().minusMonths(1), true);
     when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
-    postSubmission(ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
+    when(iosDeviceApiClient.updatePerDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok().build());
+    final ResponseEntity<DataSubmissionResponse> responseEntity = postSubmission(
+        ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
+
+    assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
+  @Test
+  void shouldFailWhenUpdatingDeviceTokenFails() {
+    PPADataRequestIOS ppaDataRequestIOS = buildPPADataRequestIosPayload(buildUuid(),
+        buildBase64String(ppacConfiguration.getIos().getMinDeviceTokenLength() + 1), true);
+    PerDeviceDataResponse data = buildIosDeviceData(OffsetDateTime.now().minusMonths(1), true);
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any())).thenReturn(ResponseEntity.ok(jsonify(data)));
+    when(iosDeviceApiClient.updatePerDeviceData(anyString(), any())).thenThrow(FeignException.class);
+    final ResponseEntity<DataSubmissionResponse> response = postSubmission(
+        ppaDataRequestIOS, testRestTemplate, UrlConstants.IOS + UrlConstants.DATA, false);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java
@@ -2,8 +2,14 @@ package app.coronawarn.datadonation.services.ppac.ios.verification;
 
 import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
 import static app.coronawarn.datadonation.common.utils.TimeUtils.getLastDayOfMonthFor;
-import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.*;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildBase64String;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildIosDeviceData;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildPPADataRequestIosPayload;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.buildUuid;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.jsonify;
+import static app.coronawarn.datadonation.services.ppac.ios.testdata.TestData.postSubmission;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -14,23 +20,25 @@ import app.coronawarn.datadonation.common.config.UrlConstants;
 import app.coronawarn.datadonation.common.persistence.domain.ApiToken;
 import app.coronawarn.datadonation.common.persistence.repository.ApiTokenRepository;
 import app.coronawarn.datadonation.common.protocols.internal.ppdd.PPADataRequestIOS;
+import app.coronawarn.datadonation.common.utils.TimeUtils;
 import app.coronawarn.datadonation.services.ppac.commons.web.DataSubmissionResponse;
 import app.coronawarn.datadonation.services.ppac.config.PpacConfiguration;
 import app.coronawarn.datadonation.services.ppac.ios.client.IosDeviceApiClient;
 import app.coronawarn.datadonation.services.ppac.ios.client.domain.PerDeviceDataResponse;
 import app.coronawarn.datadonation.services.ppac.logging.PpacErrorCode;
+import feign.FeignException;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class PpacProcessorIntegrationTest {
@@ -62,7 +70,76 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
-  public void testApiTokenQuotaExceededShouldNotTriggerAppleCall() {
+  void testNewApiTokenNotSavedWhenFurtherProcessingFails() {
+    // given
+    // - a valid ApiToken that was created now.
+    String apiToken = buildUuid();
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+    // - a device token
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    // - a data submission payload
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+
+    // when
+    // - checking the device token then return some valid mock data.
+    final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any()))
+        .thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
+    // - when updating the device data then fail
+    when(iosDeviceApiClient.updatePerDeviceData(anyString(), any()))
+        .thenThrow(FeignException.class);
+    // then
+    // - failed submission
+    postSubmission(submissionPayloadIos, testRestTemplate, IOS_SERVICE_URL, true);
+    Optional<ApiToken> optionalApiToken = apiTokenRepository.findById(apiToken);
+    // - the api token was not created.
+    assertThat(optionalApiToken).isEmpty();
+  }
+
+  @Test
+  void testExistingApiTokenRollbackAppliedWhenFurtherProcessingFails() {
+    // given
+    // - a valid ApiToken that was created now and was last used for PPA the day before. The Api Token is valid until the end of the current Month.
+    String apiToken = buildUuid();
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    final Long lastDayOfMonthForNow = TimeUtils.getLastDayOfMonthForNow();
+    final Long createdAt = now.toEpochSecond();
+    final long lastUsedForPpa = now.minus(1, ChronoUnit.DAYS).toEpochSecond();
+    apiTokenRepository.insert(apiToken, lastDayOfMonthForNow, createdAt, null, lastUsedForPpa);
+    // - a device token
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    // - a data submission payload
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+
+    // when
+    // - checking the device first throw an exception and second return some valid mock data.
+    final PerDeviceDataResponse perDeviceDataResponse = buildIosDeviceData(now.minusMonths(1), true);
+    when(iosDeviceApiClient.queryDeviceData(anyString(), any()))
+        .thenThrow(new RuntimeException()).thenReturn(ResponseEntity.ok(jsonify(perDeviceDataResponse)));
+    // then
+    // - failed submission
+    postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, true);
+    Optional<ApiToken> optionalApiToken = apiTokenRepository.findById(apiToken);
+    // - the api token's last updated timestamp is still the old one
+    assertThat(optionalApiToken).isNotEmpty();
+    assertThat(optionalApiToken.get().getLastUsedPpac()).isPresent();
+    assertThat(optionalApiToken.get().getLastUsedPpac().get()).isEqualTo(lastUsedForPpa);
+    // then
+    // - successful submission
+    postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, true);
+    Optional<ApiToken> optionalApiToken1 = apiTokenRepository.findById(apiToken);
+    // - the api token's last updated timestamp is somewhere near the createdAt timestamp.
+    assertThat(optionalApiToken1).isNotEmpty();
+    assertThat(optionalApiToken1.get().getLastUsedPpac()).isPresent();
+    assertThat(optionalApiToken1.get().getLastUsedPpac().get())
+        .isCloseTo(createdAt, within(createdAt - lastUsedForPpa));
+  }
+
+  @Test
+  void testApiTokenQuotaExceededShouldNotTriggerAppleCall() {
     String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
     String apiToken = buildUuid();
     OffsetDateTime now = OffsetDateTime.now();
@@ -81,21 +158,21 @@ public class PpacProcessorIntegrationTest {
   }
 
   @Test
-  public void testApiTokenExpiredShouldNotTriggerAppleCall() {
-      String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
-      String apiToken = buildUuid();
-      OffsetDateTime now = OffsetDateTime.now();
-      Long expirationDate = getLastDayOfMonthFor(now.minusMonths(1));
-      long timestamp = getEpochSecondFor(now);
+  void testApiTokenExpiredShouldNotTriggerAppleCall() {
+    String deviceToken = buildBase64String(this.configuration.getIos().getMinDeviceTokenLength() + 1);
+    String apiToken = buildUuid();
+    OffsetDateTime now = OffsetDateTime.now();
+    Long expirationDate = getLastDayOfMonthFor(now.minusMonths(1));
+    long timestamp = getEpochSecondFor(now);
 
-      apiTokenRepository.insert(apiToken, expirationDate, expirationDate, timestamp, timestamp);
-      PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
+    apiTokenRepository.insert(apiToken, expirationDate, expirationDate, timestamp, timestamp);
+    PPADataRequestIOS submissionPayloadIos = buildPPADataRequestIosPayload(apiToken, deviceToken, false);
 
-      ResponseEntity<DataSubmissionResponse> response = postSubmission(submissionPayloadIos, testRestTemplate,
-          IOS_SERVICE_URL, false);
+    ResponseEntity<DataSubmissionResponse> response = postSubmission(submissionPayloadIos, testRestTemplate,
+        IOS_SERVICE_URL, false);
 
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-      assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_EXPIRED);
-      verify(iosDeviceApiClient, times(0)).queryDeviceData(anyString(), any());
-    }
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(response.getBody().getErrorCode()).isEqualTo(PpacErrorCode.API_TOKEN_EXPIRED);
+    verify(iosDeviceApiClient, times(0)).queryDeviceData(anyString(), any());
+  }
 }


### PR DESCRIPTION
* fix: add logging when apitoken is used on the same day with a difference of 23 hours. Added additional tests to cover the update step of an api token to the end of ppac

* fix: organize imports

* fix: tests

* fix: remove code smells

* fix: add validateForEdus test

* Update services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/PpacProcessorIntegrationTest.java

Co-authored-by: Hilmar Falkenberg <hilmar.falkenberg@sap.com>

* fix: cover if-statement when update is 23 hours apart

* fix: integration tests

* fix: retrigger build

* fix: integration tests

* fix: integration tests

Co-authored-by: Hilmar Falkenberg <hilmar.falkenberg@sap.com>