### PR TITLE
Rename db to cwa-ppdd and adjust docker-compose to canonical. Also add data-generation script

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # Please change these default values before running docker-compose
 
 # Docker Compose Postgres settings
-POSTGRES_DB=cwa
+POSTGRES_DB=cwa-ppdd
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - pgadmin_volume:/root/.pgadmin
     ports:
-      - 8101:80
+      - "8101:80"
     restart: unless-stopped
     depends_on:
       - postgres-ppdd
@@ -16,11 +16,11 @@ services:
     image: postgres:11.5
     restart: always
     ports:
-      - 8102:5432
+      - "8102:5432"
     environment:
-      POSTGRES_DB: cwa
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   edus:
     build:
       context: ./

--- a/scripts/generate-data.sql
+++ b/scripts/generate-data.sql
@@ -1,0 +1,52 @@
+-- exposure_window
+INSERT INTO data_donation.exposure_window (
+    date,
+    report_type,
+    infectiousness,
+    callibration_confidence,
+    transmission_risk_level,
+    normalized_time,
+    cwa_version_major,
+    cwa_version_minor,
+    cwa_version_patch,
+    app_config_etag,
+    submitted_at
+)
+SELECT
+    date_trunc('day', NOW() - interval '1 month'),
+    1, -- report_type integer NOT NULL
+    1, -- infectiousness integer NOT NULL,
+    1, -- callibration_confidence integer NOT NULL,
+    1, -- transmission_risk_level integer NOT NULL,
+    12341, -- normalized_time numeric NOT NULL,
+    1, -- cwa_version_major integer NOT NULL,
+    1, -- cwa_version_minor integer NOT NULL,
+    1, -- cwa_version_patch integer NOT NULL,
+    left(md5(i::text), 100), -- app_config_etag character varying(100) COLLATE pg_catalog."default" NOT NULL,
+    date_trunc('day', NOW() - interval '1 month') -- submitted_at date NOT NULL DEFAULT CURRENT_DATE,
+FROM generate_series(1, 10000000) AS s(i)
+-- results in: INSERT 0 10000000, Query returned successfully in 37 secs 371 msec.
+
+-- scan_instance
+INSERT INTO data_donation.scan_instance (
+    exposure_window_id,
+    typical_attenuation,
+    minimum_attenuation,
+    seconds_since_last_scan,
+    submitted_at
+)
+SELECT
+    (SELECT id FROM data_donation.exposure_window ORDER BY RANDOM() LIMIT 1), -- exposure_window_id integer NOT NULL,
+    1, -- typical_attenuation integer NOT NULL,
+    1, -- minimum_attenuation integer NOT NULL,
+    1, -- seconds_since_last_scan integer NOT NULL,
+    date_trunc('day', NOW() - interval '1 month') -- submitted_at date,
+FROM generate_series(1, 100000000) AS s(i)
+-- with FK: results in: INSERT 0 100000000, Query returned successfully in 14 min 29 secs.
+-- without FK: results in: INSERT 0 100000000, Query returned successfully in 3 min 45 secs.
+
+
+select
+(select count(*) from data_donation.exposure_window) as exposure_window,
+(select count(*) from data_donation.scan_instance) as scan_instance
+


### PR DESCRIPTION
For performance analysis: 
- dispose all docker containers
- docker-compose build and up to create DB and schema
- Connect to pgadmin-ppdd using the username/password from the .env file
- Create dummy data using the below script
- Run the retention job and note execution time
- Change something (i.e. drop or add FK constraint), repeat from above