### PR TITLE
fix: handle -1 because it translates to 1969-12-31, which is not hand…

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/persistence/domain/metrics/ExposureRiskMetadata.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/persistence/domain/metrics/ExposureRiskMetadata.java
@@ -45,14 +45,14 @@ public class ExposureRiskMetadata extends DataDonationMetric {
    * risk card)
    */
   @NotNull
-  @DateInRange(from = "1970-01-01", till = "2100-01-01")
+  @DateInRange(from = "1968-01-01", till = "2100-01-01")
   private final LocalDate mostRecentDateAtRiskLevel;
 
   /**
    * The date of the most recent encounter at the given risk level (i.e. what is displayed on the
    * risk card)
    */
-  @DateInRange(from = "1970-01-01", till = "2100-01-01")
+  @DateInRange(from = "1968-01-01", till = "2100-01-01")
   private final LocalDate ptMostRecentDateAtRiskLevel;
   /**
    * Boolean to indicate if the date changed compared to the previous submission of the client.

--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/persistence/domain/metrics/ExposureRiskMetadata.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/persistence/domain/metrics/ExposureRiskMetadata.java
@@ -45,14 +45,14 @@ public class ExposureRiskMetadata extends DataDonationMetric {
    * risk card)
    */
   @NotNull
-  @DateInRange(from = "1968-01-01", till = "2100-01-01")
+  @DateInRange(from = "1969-12-31", till = "2100-01-01")
   private final LocalDate mostRecentDateAtRiskLevel;
 
   /**
    * The date of the most recent encounter at the given risk level (i.e. what is displayed on the
    * risk card)
    */
-  @DateInRange(from = "1968-01-01", till = "2100-01-01")
+  @DateInRange(from = "1969-12-31", till = "2100-01-01")
   private final LocalDate ptMostRecentDateAtRiskLevel;
   /**
    * Boolean to indicate if the date changed compared to the previous submission of the client.

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/android/testdata/TestData.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/android/testdata/TestData.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +80,7 @@ public class TestData {
 
   public static String getJwsPayloadWithUnacceptedApkCertificateDigestHash() throws IOException {
     Map<String, Serializable> payloadValues = new HashMap<>(getJwsPayloadDefaultValue());
-    payloadValues.put("apkCertificateDigestSha256", new String[] { "" });
+    payloadValues.put("apkCertificateDigestSha256", new String[]{""});
     String encodedJws = JwsGenerationUtil.createCompactSerializedJws(payloadValues);
     return encodedJws;
   }
@@ -135,7 +136,7 @@ public class TestData {
     return Map.of("nonce", TEST_NONCE_VALUE, "timestampMs",
         String.valueOf(Instant.now().minusSeconds(500).toEpochMilli()), "apkPackageName", TEST_APK_PACKAGE_NAME,
         "apkDigestSha256", "9oiqOMQAZfBgCnI0jyN7TgPAQNSSxWrjh14f0eXpB3U=", "ctsProfileMatch", "false",
-        "apkCertificateDigestSha256", new String[] { TEST_APK_CERTIFICATE_DIGEST }, "basicIntegrity", "false", "advice",
+        "apkCertificateDigestSha256", new String[]{TEST_APK_CERTIFICATE_DIGEST}, "basicIntegrity", "false", "advice",
         "RESTORE_TO_FACTORY_ROM,LOCK_BOOTLOADER", "evaluationType", "BASIC");
   }
 
@@ -147,7 +148,7 @@ public class TestData {
 
   public static ExposureRiskMetadata getInvalidExposureRiskMetadata() {
     return ExposureRiskMetadata.newBuilder().setRiskLevel(PPARiskLevel.RISK_LEVEL_HIGH)
-        .setMostRecentDateAtRiskLevel(LocalDate.of(1969,1,1).toEpochDay())
+        .setMostRecentDateAtRiskLevel(LocalDate.of(1969, 1, 1).atStartOfDay(ZoneOffset.UTC).toEpochSecond())
         .setRiskLevelChangedComparedToPreviousSubmission(true).build();
   }
 
@@ -286,7 +287,7 @@ public class TestData {
               .addAllNewExposureWindows(setOfElements(numberOFElements, () -> PPANewExposureWindow.newBuilder()
                   // for each element make sure to set a random value to a field to avoid
                   // element duplication in sets
-                  .setNormalizedTime(RandomUtils.nextDouble()).setTransmissionRiskLevel(RandomUtils.nextInt(0,3))
+                  .setNormalizedTime(RandomUtils.nextDouble()).setTransmissionRiskLevel(RandomUtils.nextInt(0, 3))
                   .setExposureWindow(PPAExposureWindow.newBuilder()
                       .addAllScanInstances(setOfElements(2,
                           () -> PPAExposureWindowScanInstance.newBuilder().setMinAttenuation(RandomUtils.nextInt())


### PR DESCRIPTION
- it is possible that clients send a -1 as mostrecentdataAtRiskLevel --> this will translate to a localdate 1969-12-31 which is not handled by the validator which starts at 1970-01-01