### PR TITLE
Bump log4j.version from 2.17.0 to 2.17.1 (#386)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,3 @@ jobs:
       - run:
           command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
           when: always
-
-workflows:
-  circleci:
-    jobs:
-      - build:
-          context: SonarCloud

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <spring-retry.version>1.3.1</spring-retry.version>
     <protobuf.version>3.19.1</protobuf.version>
     <json-simple.version>1.1.1</json-simple.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <feign.version>11.7</feign.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <dom4j.version>2.1.3</dom4j.version>


### PR DESCRIPTION
Bumps `log4j.version` from 2.17.0 to 2.17.1.

Updates `log4j-core` from 2.17.0 to 2.17.1

Updates `log4j-slf4j-impl` from 2.17.0 to 2.17.1

Updates `log4j-jul` from 2.17.0 to 2.17.1

Updates `log4j-api` from 2.17.0 to 2.17.1

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.logging.log4j:log4j-slf4j-impl
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.logging.log4j:log4j-jul
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>