### PR TITLE
Bump copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A list of all public repositories from the Corona-Warn-App can be found [here](h
 
 ## Licensing
 
-Copyright (c) 2021-2022 SAP SE or an SAP affiliate company and Corona-Warn-App contributors.
+Copyright (c) 2021-2023 SAP SE or an SAP affiliate company and Corona-Warn-App contributors.
 
 Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
 


### PR DESCRIPTION
## Description

This PR bumps the copyright year in the README.md file.

Happy new year! 🎉

### Note

This PR should only be merged once a change to any content of this repository was done.

---
Internal Tracking ID: [EXPOSUREAPP-14521](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14521)