### PR TITLE
Fix/ppac ios srs api token rate limit

### DIFF
--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
@@ -150,11 +150,19 @@ public class TimeUtils {
     return String.format("%02d:%02d:%02d", hours, remainderMinutes, remainderSeconds);
   }
 
+  /**
+   * Format the given seconds to a human-readable format, something like "dd days, hh:MM:ss", e.g. "5 days, 07:18:14". <br />
+   * Note: A negative input will result in something like -16:-41:-44 ... on purpose.
+   *
+   * @param seconds The seconds to format to a String.
+   * @return A String displaying the seconds in human-readable format.
+   */
   public static String formatToDays(long seconds) {
     long days = SECONDS.toDays(seconds);
     long remainderHours = SECONDS.toHours(seconds - DAYS.toSeconds(days));
     long remainderMinutes = SECONDS.toMinutes(seconds - (HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days)));
-    long remainderSeconds = seconds - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days));
+    long remainderSeconds = seconds -
+        (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days));
     return String.format("%02d days, %02d:%02d:%02d", days, remainderHours, remainderMinutes, remainderSeconds);
   }
 

--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
@@ -151,7 +151,8 @@ public class TimeUtils {
   }
 
   /**
-   * Format the given seconds to a human-readable format, something like "dd days, hh:MM:ss", e.g. "5 days, 07:18:14". <br />
+   * Format the given seconds to a human-readable format, something like "dd days, hh:MM:ss",
+   * e.g. "5 days, 07:18:14". <br />
    * Note: A negative input will result in something like -16:-41:-44 ... on purpose.
    *
    * @param seconds The seconds to format to a String.
@@ -161,8 +162,8 @@ public class TimeUtils {
     long days = SECONDS.toDays(seconds);
     long remainderHours = SECONDS.toHours(seconds - DAYS.toSeconds(days));
     long remainderMinutes = SECONDS.toMinutes(seconds - (HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days)));
-    long remainderSeconds = seconds -
-        (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days));
+    long remainderSeconds = seconds
+        - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days));
     return String.format("%02d days, %02d:%02d:%02d", days, remainderHours, remainderMinutes, remainderSeconds);
   }
 

--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
@@ -152,10 +152,10 @@ public class TimeUtils {
 
   public static String formatToDays(long seconds) {
     long days = SECONDS.toDays(seconds);
-    long remainderhours = SECONDS.toHours(seconds - DAYS.toHours(days));
-    long remainderMinutes = SECONDS.toMinutes(seconds - (HOURS.toSeconds(remainderhours) + DAYS.toHours(days)));
-    long remainderSeconds = seconds - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderhours) + DAYS.toHours(days));
-    return String.format("%02d days, %02d:%02d:%02d", days, remainderhours, remainderMinutes, remainderSeconds);
+    long remainderHours = SECONDS.toHours(seconds - DAYS.toSeconds(days));
+    long remainderMinutes = SECONDS.toMinutes(seconds - (HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days)));
+    long remainderSeconds = seconds - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days));
+    return String.format("%02d days, %02d:%02d:%02d", days, remainderHours, remainderMinutes, remainderSeconds);
   }
 
   /**

--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
@@ -1,6 +1,7 @@
 package app.coronawarn.datadonation.common.utils;
 
 import static java.time.ZoneOffset.UTC;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -147,6 +148,14 @@ public class TimeUtils {
     long remainderMinutes = SECONDS.toMinutes(seconds - HOURS.toSeconds(hours));
     long remainderSeconds = seconds - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(hours));
     return String.format("%02d:%02d:%02d", hours, remainderMinutes, remainderSeconds);
+  }
+
+  public static String formatToDays(long seconds) {
+    long days = SECONDS.toDays(seconds);
+    long remainderhours = SECONDS.toHours(seconds - DAYS.toHours(days));
+    long remainderMinutes = SECONDS.toMinutes(seconds - (HOURS.toSeconds(remainderhours) + DAYS.toHours(days)));
+    long remainderSeconds = seconds - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderhours) + DAYS.toHours(days));
+    return String.format("%02d days, %02d:%02d:%02d", days, remainderhours, remainderMinutes, remainderSeconds);
   }
 
   /**

--- a/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
+++ b/common/persistence/src/main/java/app/coronawarn/datadonation/common/utils/TimeUtils.java
@@ -164,7 +164,7 @@ public class TimeUtils {
     long remainderMinutes = SECONDS.toMinutes(seconds - (HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days)));
     long remainderSeconds = seconds
         - (MINUTES.toSeconds(remainderMinutes) + HOURS.toSeconds(remainderHours) + DAYS.toSeconds(days));
-    return String.format("%02d days, %02d:%02d:%02d", days, remainderHours, remainderMinutes, remainderSeconds);
+    return String.format("%01d days, %02d:%02d:%02d", days, remainderHours, remainderMinutes, remainderSeconds);
   }
 
   /**

--- a/common/persistence/src/test/java/app/coronawarn/datadonation/common/utils/TimeUtilsTest.java
+++ b/common/persistence/src/test/java/app/coronawarn/datadonation/common/utils/TimeUtilsTest.java
@@ -1,5 +1,6 @@
 package app.coronawarn.datadonation.common.utils;
 
+import static app.coronawarn.datadonation.common.utils.TimeUtils.formatToDays;
 import static app.coronawarn.datadonation.common.utils.TimeUtils.formatToHours;
 import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochMilliSecondForNow;
 import static app.coronawarn.datadonation.common.utils.TimeUtils.getEpochSecondFor;
@@ -128,5 +129,15 @@ class TimeUtilsTest {
     assertThat(formatToHours(-1)).isEqualTo("00:00:-1");
     assertThat(formatToHours(86100)).isEqualTo("23:55:00");
     assertThat(formatToHours(-86100)).isEqualTo("-23:-55:00");
+  }
+
+  @Test
+  void testFormatToDays() {
+    assertThat(formatToDays(0)).isEqualTo("0 days, 00:00:00");
+    assertThat(formatToDays(1)).isEqualTo("0 days, 00:00:01");
+    assertThat(formatToDays(-1)).isEqualTo("0 days, 00:00:-1");
+    assertThat(formatToDays(7776000)).isEqualTo("90 days, 00:00:00");
+    assertThat(formatToDays(7776010)).isEqualTo("90 days, 00:00:10");
+    assertThat(formatToDays(7775990)).isEqualTo("89 days, 23:59:50");
   }
 }

--- a/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/config/PpacConfiguration.java
+++ b/services/ppac/src/main/java/app/coronawarn/datadonation/services/ppac/config/PpacConfiguration.java
@@ -236,8 +236,6 @@ public class PpacConfiguration {
     @NotEmpty
     private String ppacIosJwtTeamId;
 
-    private int srsApiTokenRateLimitSeconds;
-
     public Integer getApiTokenRateLimitSeconds() {
       return apiTokenRateLimitSeconds;
     }
@@ -268,10 +266,6 @@ public class PpacConfiguration {
 
     public String getPpacIosJwtTeamId() {
       return ppacIosJwtTeamId;
-    }
-
-    public int getSrsApiTokenRateLimitSeconds() {
-      return srsApiTokenRateLimitSeconds;
     }
 
     public void setApiTokenRateLimitSeconds(final Integer apiTokenRateLimitSeconds) {
@@ -305,10 +299,6 @@ public class PpacConfiguration {
 
     public void setPpacIosJwtTeamId(final String ppacIosJwtTeamId) {
       this.ppacIosJwtTeamId = ppacIosJwtTeamId;
-    }
-
-    public void setSrsApiTokenRateLimitSeconds(final int srsApiTokenRateLimitSeconds) {
-      this.srsApiTokenRateLimitSeconds = srsApiTokenRateLimitSeconds;
     }
   }
 

--- a/services/ppac/src/main/resources/application.yaml
+++ b/services/ppac/src/main/resources/application.yaml
@@ -87,7 +87,6 @@ ppac:
     min_device_token_length: ${PPAC_IOS_DEVICE_TOKEN_MIN_LENGTH:2500}
     max_device_token_length: ${PPAC_IOS_DEVICE_TOKEN_MAX_LENGTH:3500}
     api-token-rate-limit-seconds: ${PPAC_IOS_API_TOKEN_RATE_LIMIT_SECONDS:86100}
-    srs-api-token-rate-limit-seconds: ${PPAC_IOS_SRS_API_TOKEN_RATE_LIMIT_SECONDS:7776000}
   android:
     certificate-hostname: ${PPAC_ANDROID_CERTIFICATE_HOSTNAME:attest.android.com}
     attestation-validity: ${PPAC_ANDROID_ATTESTATION_VALIDITY_IN_SECONDS:7200}

--- a/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategyTest.java
+++ b/services/ppac/src/test/java/app/coronawarn/datadonation/services/ppac/ios/verification/scenario/ratelimit/ProdPpacIosRateLimitStrategyTest.java
@@ -34,7 +34,7 @@ class ProdPpacIosRateLimitStrategyTest {
     Ios ios = new Ios();
     configuration.setIos(ios);
     ios.setApiTokenRateLimitSeconds(86100);
-    ios.setSrsApiTokenRateLimitSeconds(602700);
+    configuration.setSrsTimeBetweenSubmissionsInDays(7);
     underTest = new ProdPpacIosRateLimitStrategy(configuration);
   }
 


### PR DESCRIPTION
Use the same (existing) env variable srsTimeBetweenSubmissionsInDays for both Android and iOS. Also fixes 


```
Description:
Failed to bind properties under 'ppac.ios.srs-api-token-rate-limit-seconds' to int:
Property: ppac.ios.srs-api-token-rate-limit-seconds
Value: "7.776e+06"
Origin: System Environment Property "PPAC_IOS_SRS_API_TOKEN_RATE_LIMIT_SECONDS"
Reason: failed to convert java.lang.String to int (caused by java.lang.NumberFormatException: For input string: "7.776e+06")

Action: Update your application's configuration.
```